### PR TITLE
redirect cpu logger to QueueLoggingHandler

### DIFF
--- a/src/cpu/logging/queue_handler.py
+++ b/src/cpu/logging/queue_handler.py
@@ -11,6 +11,7 @@ LoggingComponent via a message queue.
 from __future__ import annotations
 
 import logging
+import threading
 
 from cpu.messaging.interfaces import MessageQueueInterface, QueueFullError
 from cpu.messaging.message import Message, MessageType
@@ -52,6 +53,7 @@ class QueueLoggingHandler(logging.Handler):
         super().__init__()
         self._queue = queue
         self._source = source_component
+        self._emitting = threading.local()
 
     def emit(self, record: logging.LogRecord) -> None:
         """
@@ -60,9 +62,19 @@ class QueueLoggingHandler(logging.Handler):
         Converts the LogRecord to a Message with type LOG and sends
         it to the queue for processing by LoggingComponent.
 
+        Log calls made by the messaging infrastructure itself while
+        emitting (e.g. Message creation logs at DEBUG, queue.put logs
+        at TRACE) are dropped to prevent infinite recursion.
+
         Args:
             record: LogRecord to process
         """
+        # re-entry guard: creating/queueing the Message below triggers
+        # log calls on cpu.messaging.* loggers, which land in this same
+        # handler and would recurse forever
+        if getattr(self._emitting, "active", False):
+            return
+        self._emitting.active = True
         try:
             # format the message using configured formatter
             message_text = self.format(record)
@@ -92,3 +104,5 @@ class QueueLoggingHandler(logging.Handler):
             # CRITICAL: don't raise exceptions from logging
             # this would break the component using the logger
             self.handleError(record)
+        finally:
+            self._emitting.active = False

--- a/src/cpu/logging/setup.py
+++ b/src/cpu/logging/setup.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from typing import Any
 
 from cpu.config.config import Config
+from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.messaging.interfaces import MessageQueueInterface
+from cpu.messaging.message import Message
 
 # define TRACE level (below DEBUG)
 TRACE = 5
@@ -103,3 +106,36 @@ def configure_logging(config: Config) -> None:
             logger.setLevel(TRACE)
         else:
             logger.setLevel(getattr(logging, logger_level.upper()))
+
+
+def configure_queue_logging(
+    log_queue: MessageQueueInterface[Message],
+    source_component: str = "cpu",
+    level: int = logging.INFO,
+) -> None:
+    """
+    Configure queue-based logging for the cpu package.
+
+    Replaces all handlers on the "cpu" logger with a QueueLoggingHandler,
+    so every log call from cpu.* modules is sent to the LoggingComponent
+    via the message queue instead of being written directly.
+
+    Args:
+        log_queue: Queue to send log messages to
+        source_component: Name attached as message source
+        level: Minimum log level to send to the queue
+    """
+    cpu_logger = logging.getLogger("cpu")
+
+    # remove any existing handlers to avoid duplicate log paths
+    cpu_logger.handlers.clear()
+
+    # add queue handler
+    queue_handler = QueueLoggingHandler(log_queue, source_component)
+    queue_handler.setLevel(level)
+    cpu_logger.addHandler(queue_handler)
+
+    cpu_logger.setLevel(level)
+
+    # don't propagate to root logger (would bypass the queue)
+    cpu_logger.propagate = False

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -14,7 +14,10 @@ from pathlib import Path
 import pytest
 
 from cpu.config.config import Config
-from cpu.logging.setup import TRACE, configure_logging
+from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.logging.setup import TRACE, configure_logging, configure_queue_logging
+from cpu.messaging.message import Message, MessageType
+from cpu.messaging.queue_thread import ThreadMessageQueue
 
 
 class TestTraceLevel:
@@ -183,3 +186,92 @@ bot:
 
         root_logger = logging.getLogger()
         assert root_logger.level == TRACE
+
+
+class TestConfigureQueueLogging:
+    """Test queue-based logging configuration."""
+
+    def test_cpu_logger_gets_queue_handler(self) -> None:
+        """Test the cpu logger is configured with a QueueLoggingHandler."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue)
+
+        cpu_logger = logging.getLogger("cpu")
+        assert len(cpu_logger.handlers) == 1
+        assert isinstance(cpu_logger.handlers[0], QueueLoggingHandler)
+
+    def test_log_message_lands_in_queue(self) -> None:
+        """Test a log call on a cpu.* logger ends up in the queue."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue)
+
+        logger = logging.getLogger("cpu.some.module")
+        logger.info("Hello queue")
+
+        msg = log_queue.get(timeout=1)
+        assert msg.type == MessageType.LOG
+        assert "Hello queue" in msg.payload["message"]
+        assert msg.payload["name"] == "cpu.some.module"
+
+    def test_existing_handlers_replaced(self) -> None:
+        """Test previously configured handlers are removed."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        cpu_logger = logging.getLogger("cpu")
+        cpu_logger.addHandler(logging.NullHandler())
+        cpu_logger.addHandler(logging.NullHandler())
+
+        configure_queue_logging(log_queue)
+
+        assert len(cpu_logger.handlers) == 1
+        assert isinstance(cpu_logger.handlers[0], QueueLoggingHandler)
+
+    def test_no_propagation_to_root(self) -> None:
+        """Test cpu logger does not propagate to root logger."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue)
+
+        cpu_logger = logging.getLogger("cpu")
+        assert cpu_logger.propagate is False
+
+    def test_level_respected(self) -> None:
+        """Test messages below the configured level are not queued."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue, level=logging.WARNING)
+
+        logger = logging.getLogger("cpu.some.module")
+        logger.info("Filtered out")
+        logger.warning("Passes through")
+
+        msg = log_queue.get(timeout=1)
+        assert "Passes through" in msg.payload["message"]
+        assert log_queue.empty()
+
+    def test_trace_level_supported(self) -> None:
+        """Test TRACE level messages flow through when configured."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue, level=TRACE)
+
+        logger = logging.getLogger("cpu.some.module")
+        logger.log(TRACE, "Trace through queue")
+
+        msg = log_queue.get(timeout=1)
+        assert msg.payload["level"] == TRACE
+        assert "Trace through queue" in msg.payload["message"]
+
+    def test_source_component_set(self) -> None:
+        """Test the source component name is attached to messages."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue, source_component="event_handler")
+
+        logger = logging.getLogger("cpu.some.module")
+        logger.info("Tagged message")
+
+        msg = log_queue.get(timeout=1)
+        assert msg.source == "event_handler"


### PR DESCRIPTION
- include unit tests
- prevents recursion of log messages in the queue_handler