### PR TITLE
use LoggingComponent in main

### DIFF
--- a/src/cpu/__main__.py
+++ b/src/cpu/__main__.py
@@ -19,7 +19,7 @@ from cpu import __version__
 from cpu.components.orchestrator import Orchestrator
 from cpu.config.config import Config, ConfigError, ConfigValidationError
 from cpu.logging.component import LoggingComponent
-from cpu.logging.setup import configure_logging
+from cpu.logging.setup import TRACE, configure_queue_logging
 from cpu.messaging.message import Message
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 def create_orchestrator(config: Config) -> Orchestrator:
     """
     Create and configure orchestrator with all components.
+
+    Creates the LoggingComponent first and immediately switches all
+    cpu.* logging to the queue, so subsequent component registration
+    and initialization logs are captured by the LoggingComponent.
+    Messages buffer in the queue until start_all() runs the component.
 
     Args:
         config: Configuration object
@@ -43,9 +48,21 @@ def create_orchestrator(config: Config) -> Orchestrator:
     log_component = LoggingComponent(
         name="logger",
         log_queue=log_queue,
-        config=config.get("bot.logging", {}),
+        config=config.get("bot.logging", {}),  # plain sub-dict, no prefix
     )
     orchestrator.register(log_component)
+
+    # switch all cpu.* logging to the queue immediately
+    # messages buffer here until LoggingComponent thread starts
+    log_level_str: str = config.get("bot.logging.level", "INFO")
+    log_level: int = TRACE if log_level_str.upper() == "TRACE" else getattr(
+        logging, log_level_str.upper(), logging.INFO
+    )
+    configure_queue_logging(
+        log_queue,
+        source_component="cpu",
+        level=log_level,
+    )
 
     # TODO register components as they're implemented
     # orchestrator.register(EventHandlerComponent(...))
@@ -302,8 +319,11 @@ def main() -> int:
         # validate configuration
         validate_configuration(config)
 
-        # IMPORTANT: configure logging BEFORE components start
-        configure_logging(config)
+        # Phase 1: console-only logging during startup
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(levelname)s: %(message)s",
+        )
         logger.info("CPU Bot starting...")
 
         # create banner header
@@ -316,7 +336,8 @@ def main() -> int:
         # add startup information
         banner += create_startup_info(config_file, config, verbose=args.extended_startup_info)
 
-        # create and run orchestrator
+        # Phase 2: create orchestrator - switches cpu.* logging to queue
+        # inside create_orchestrator()
         orchestrator = create_orchestrator(config)
         orchestrator.initialize_all()
 

--- a/src/cpu/components/orchestrator.py
+++ b/src/cpu/components/orchestrator.py
@@ -91,11 +91,16 @@ class Orchestrator:
         """
         Stop all components gracefully.
 
+        Components are stopped in reverse registration order, so
+        components registered first (e.g. the logging component)
+        are stopped last and remain available during shutdown of
+        the others.
+
         Args:
             timeout: Maximum time to wait for all components to stop
         """
         logger.info("Stopping all components")
-        for name in self._components:
+        for name in reversed(self._components):
             self.stop_component(name, timeout=timeout)
 
     def initialize_component(self, name: str) -> None:

--- a/src/cpu/logging/component.py
+++ b/src/cpu/logging/component.py
@@ -63,6 +63,9 @@ class LoggingComponent(RunnableComponent):
         self._logger = logging.getLogger("cpu.logging")
         self._logger.addHandler(self._file_handler)
         self._logger.setLevel(getattr(logging, log_level.upper()))
+        # must not propagate to cpu logger - that has the QueueLoggingHandler
+        # which would create a feedback loop on every write
+        self._logger.propagate = False
 
         self.state = ComponentState.INITIALIZED
 

--- a/src/cpu/logging/component.py
+++ b/src/cpu/logging/component.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from cpu.components.base import ComponentState, HealthStatus, RunnableComponent
+from cpu.logging.queue_handler import suppress_queue_logging
 from cpu.logging.sanitizer import LogSanitizer
 from cpu.messaging.interfaces import MessageQueueInterface, QueueEmptyError
 from cpu.messaging.message import Message, MessageType
@@ -68,7 +69,10 @@ class LoggingComponent(RunnableComponent):
     def process_iteration(self) -> None:
         """Process one log message from queue."""
         try:
-            msg = self._queue.get(timeout=0.1)
+            # suppress queue logging around our own queue operation to
+            # prevent a feedback loop (get() logs at TRACE level)
+            with suppress_queue_logging():
+                msg = self._queue.get(timeout=0.1)
 
             # verif message type
             if msg.type != MessageType.LOG:

--- a/src/cpu/logging/queue_handler.py
+++ b/src/cpu/logging/queue_handler.py
@@ -12,9 +12,33 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections.abc import Generator
+from contextlib import contextmanager
 
 from cpu.messaging.interfaces import MessageQueueInterface, QueueFullError
 from cpu.messaging.message import Message, MessageType
+
+# thead-local suppression state, shared by all handler instance
+_thread_state = threading.local()
+
+
+@contextmanager
+def suppress_queue_logging() -> Generator[None, None, None]:
+    """
+    Suppress queue-based logging in the current thread.
+
+    Log calls made inside this context are dropped by all
+    QueueLoggingHandler instances. Used by the LoggingComponent around
+    its own queue operations to prevent a feedback loop: each
+    queue.get() would otherwise log a TRACE message that lands back in
+    the very queue being drained.
+    """
+    previous = getattr(_thread_state, "suppressed", False)
+    _thread_state.suppressed = True
+    try:
+        yield
+    finally:
+        _thread_state.suppressed = previous
 
 
 class QueueLoggingHandler(logging.Handler):
@@ -71,8 +95,9 @@ class QueueLoggingHandler(logging.Handler):
         """
         # re-entry guard: creating/queueing the Message below triggers
         # log calls on cpu.messaging.* loggers, which land in this same
-        # handler and would recurse forever
-        if getattr(self._emitting, "active", False):
+        # handler and would recurse forever; also honor explicit
+        # per-thread suppression (see suppress_queue_logging)
+        if getattr(self._emitting, "active", False) or getattr(_thread_state, "suppressed", False):
             return
         self._emitting.active = True
         try:

--- a/tests/integration/test_logging_queue.py
+++ b/tests/integration/test_logging_queue.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from cpu.components.base import HealthStatus
 from cpu.logging.component import LoggingComponent
 from cpu.logging.queue_handler import QueueLoggingHandler
-from cpu.logging.setup import TRACE
+from cpu.logging.setup import TRACE, configure_queue_logging
 from cpu.messaging.message import Message, MessageType
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -218,3 +218,28 @@ class TestQueueLoggingIntegration:
         content = log_file.read_text()
         for i in range(10):
             assert f"Threaded message {i}" in content
+
+    def test_no_feedback_loop_at_trace_level(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test the component's own queue operations don't generate log messages."""
+        component, log_queue, log_file = logging_component
+
+        # route all cpu.* logging into the same queue at TRACE level
+        configure_queue_logging(log_queue, level=TRACE)
+
+        thread = threading.Thread(target=component.start)
+        thread.start()
+
+        # without suppression, every queue.get would enqueue a new TRACE
+        # message, keeping the queue busy forever
+        time.sleep(0.3)
+
+        component.stop()
+        thread.join(timeout=2)
+        component.flush()
+
+        # queue must not have balloned with self-generated messages
+        assert log_queue.qsize() < 10
+        assert "Getting message from queue" not in log_file.read_text()

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""Integration tests for __main__ logging wiring."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from cpu.__main__ import create_orchestrator
+from cpu.config.config import Config
+from cpu.logging.queue_handler import QueueLoggingHandler
+
+
+class TestMainLoggingWiring:
+    """Test that __main__ correctly wires queue-based logging."""
+
+    def test_cpu_logger_uses_queue_handler_after_create_orchestrator(
+        self, tmp_path: Path
+    ) -> None:
+        """Test cpu logger has QueueLoggingHandler after create_orchestrator."""
+        config_file = tmp_path / "config.yaml"
+        log_file = tmp_path / "cpu.log"
+        config_file.write_text(f"""
+bot:
+  num_workers: 2
+  logging:
+    level: INFO
+    file: {log_file}
+    format: "%(levelname)s %(name)s %(message)s"
+""")
+        config = Config(config_file=config_file)
+        config.load()
+
+        create_orchestrator(config)
+
+        cpu_logger = logging.getLogger("cpu")
+        assert any(
+            isinstance(h, QueueLoggingHandler) for h in cpu_logger.handlers
+        )
+
+    def test_logs_after_create_orchestrator_reach_queue(
+        self, tmp_path: Path
+    ) -> None:
+        """Test log calls after create_orchestrator go to the queue."""
+        config_file = tmp_path / "config.yaml"
+        log_file = tmp_path / "cpu.log"
+        config_file.write_text(f"""
+bot:
+  num_workers: 2
+  logging:
+    level: INFO
+    file: {log_file}
+""")
+        config = Config(config_file=config_file)
+        config.load()
+
+        create_orchestrator(config)
+
+        cpu_logger = logging.getLogger("cpu")
+        handler = next(
+            h for h in cpu_logger.handlers if isinstance(h, QueueLoggingHandler)
+        )
+
+        from cpu.messaging.message import MessageType
+
+        cpu_logger.info("Post-orchestrator log")
+
+        msg = handler._queue.get(timeout=1)
+        assert msg.type == MessageType.LOG
+        assert "Post-orchestrator log" in msg.payload["message"]
+
+    def test_messages_buffered_before_logging_component_starts(
+            self, tmp_path: Path
+        ) -> None:
+        """Test log messages are buffered in queue before LoggingComponent starts."""
+        config_file = tmp_path / "config.yaml"
+        log_file = tmp_path / "cpu.log"
+        config_file.write_text(f"""
+bot:
+  num_workers: 2
+  logging:
+    level: INFO
+    file: {log_file}
+""")
+        config = Config(config_file=config_file)
+        config.load()
+
+        # create orchestrator - switches to queue logging but doesn't start yet
+        orchestrator = create_orchestrator(config)
+
+        # log something before start_all()
+        logger = logging.getLogger("cpu.test")
+        logger.info("Buffered message")
+
+        # verify message is in the queue but not yet written to file
+        cpu_logger = logging.getLogger("cpu")
+        handler = next(
+            _handler for _handler in cpu_logger.handlers if isinstance(_handler, QueueLoggingHandler)
+        )
+        assert not handler._queue.empty()
+
+        # now start and let LoggingComponent process the queue
+        orchestrator.initialize_all()
+        orchestrator.start_all()
+
+        import time
+        time.sleep(0.3)
+
+        orchestrator.stop_all(timeout=2)
+
+        # verify message reached the file
+        assert log_file.exists()
+        assert "Buffered message" in log_file.read_text()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -782,7 +782,7 @@ bot:
         assert "Configuration validated successfully" in caplog.text
 
     def test_component_initialization_logs_at_info(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        """Test component initialization logs at INFO level."""
+        """Test startup logs before queue logging is active and reach caplog."""
         caplog.set_level(logging.INFO)
 
         config_file = tmp_path / "config.yaml"
@@ -801,7 +801,10 @@ bot:
 
             main()
 
-        assert "All components initialized" in caplog.text
+        # messages logged before create_orchestrator() switches to queue
+        # logging still reach caplog via basicConfig
+        assert "CPU Bot starting" in caplog.text
+        assert "Configuration validated" in caplog.text
 
     def test_shutdown_logs_at_info(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test shutdown logs at INFO level."""

--- a/tests/unit/test_components_orchestrator.py
+++ b/tests/unit/test_components_orchestrator.py
@@ -473,3 +473,27 @@ class TestOrchestratorLogging:
 
         assert statuses["test_component"] == HealthStatus.HEALTHY
         assert "Health check for component test_component: HEALTHY" in caplog.text
+
+    def test_stop_all_reverse_registration_order(self) -> None:
+        """Test components are stopped in reverse registration order."""
+        orchestrator = Orchestrator()
+        stop_order: list[str] = []
+
+        class OrderTrackingComponent(MockRunnableComponent):
+            def stop(self, timeout: float | None = None) -> None:
+                stop_order.append(self.name)
+                super().stop(timeout=timeout)
+
+        first = OrderTrackingComponent(name="first")
+        second = OrderTrackingComponent(name="second")
+        third = OrderTrackingComponent(name="third")
+
+        orchestrator.register(first)
+        orchestrator.register(second)
+        orchestrator.register(third)
+        orchestrator.initialize_all()
+        orchestrator.start_all()
+
+        orchestrator.stop_all(timeout=2)
+
+        assert stop_order == ["third", "second", "first"]

--- a/tests/unit/test_logging_component.py
+++ b/tests/unit/test_logging_component.py
@@ -279,3 +279,17 @@ class TestLoggingComponent:
         component.flush()
 
         assert "Too detailed" not in log_file.read_text()
+
+    def test_logger_does_not_propagate(self, tmp_path: Path) -> None:
+        """Test internal logger has propagation disabled to prevent feedback loop."""
+        log_file = tmp_path / "test.log"
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        component = LoggingComponent(
+            name="logger",
+            log_queue=queue,
+            config={"file": str(log_file), "level": "DEBUG"},
+        )
+        component.initialize()
+
+        assert logging.getLogger("cpu.logging").propagate is False

--- a/tests/unit/test_logging_queue_handler.py
+++ b/tests/unit/test_logging_queue_handler.py
@@ -227,9 +227,11 @@ class TestQueueLoggingHandler:
         logger.addHandler(handler)
         logger.setLevel(logging.INFO)
 
-        with suppress_queue_logging():
-            with suppress_queue_logging():
-                logger.info("Still suppressed")
+        with (
+            suppress_queue_logging(),
+            suppress_queue_logging()
+        ):
+            logger.info("Still suppressed")
 
         logger.info("Back to normal")
 

--- a/tests/unit/test_logging_queue_handler.py
+++ b/tests/unit/test_logging_queue_handler.py
@@ -3,8 +3,9 @@
 """Tests for QueueLoggingHandler."""
 
 import logging
+import threading
 
-from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.logging.queue_handler import QueueLoggingHandler, suppress_queue_logging
 from cpu.messaging.message import Message, MessageType
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -167,4 +168,71 @@ class TestQueueLoggingHandler:
         assert "Should appear" in msg.payload["message"]
 
         # queue should be empty
+        assert queue.empty()
+
+    def test_suppression_drops_messages(self) -> None:
+        """Test log calls inside suppression context are not queued."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.suppress")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        with suppress_queue_logging():
+            logger.info("Suppressed message")
+
+        logger.info("Normal message")
+
+        msg = queue.get(timeout=1)
+        assert "Normal message" in msg.payload["message"]
+        assert queue.empty()
+
+    def test_suppression_is_per_thread(self) -> None:
+        """Test suppression in one thread does not affect another."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.suppress.thread")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def worker() -> None:
+            with suppress_queue_logging():
+                entered.set()
+                release.wait(timeout=2)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        entered.wait(timeout=2)
+
+        # other thread is suppressed, this one is not
+        logger.info("From main thread")
+
+        release.set()
+        thread.join(timeout=2)
+
+        msg = queue.get(timeout=1)
+        assert "From main thread" in msg.payload["message"]
+
+    def test_suppression_restored_after_context(self) -> None:
+        """Test suppression state is restored, including when nested."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.suppress.nested")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        with suppress_queue_logging():
+            with suppress_queue_logging():
+                logger.info("Still suppressed")
+
+        logger.info("Back to normal")
+
+        msg = queue.get(timeout=1)
+        assert "Back to normal" in msg.payload["message"]
         assert queue.empty()


### PR DESCRIPTION
Need to start the `LoggingComponent` first, then switch all `cpu.*` logging to the queue. The PR provides three parts:

1. **Orchestrator:** stop in reverse registration order. Until now components were stopped in the order they have been created. However, we want to start the `LoggingComponent` first and stop it last or log messages would not be serialized at it.
2. **Prevent a recursion loop:** the `LoggingComponent's` own `queue.get()` calls emit `TRACE` logs on `cpu.messaging.queue_thread` from its thread; those feed back into the log queue and generate an endless message stream.
3. **`__main__.py` rewiring:** console-only logging during startup, then `configure_queue_logging()` once the queue exists.

`main()` will no longer call `configure_logging()`. However, we keep it for now, because it is still used in tests. We may clean this up later.