### PR TITLE
cleanup unused function, use CompressingRotatingFileHandler and minor improvements

### DIFF
--- a/src/cpu/__main__.py
+++ b/src/cpu/__main__.py
@@ -321,7 +321,7 @@ def main() -> int:
 
         # Phase 1: console-only logging during startup
         logging.basicConfig(
-            level=logging.INFO,
+            level=logging.WARNING,
             format="%(levelname)s: %(message)s",
         )
         logger.info("CPU Bot starting...")

--- a/src/cpu/__main__.py
+++ b/src/cpu/__main__.py
@@ -185,10 +185,10 @@ def print_banner(banner: str, config: Config | None = None) -> None:
     """
     # check if terminal effects are enabled in config
     enable_effects = False
-    effect_name = "Slide"
+    effect_name = "Beams"
     if config is not None:
         enable_effects = config.get("bot.banner_effects", False)
-        effect_name = config.get("bot.banner_effect_type", "Slide")
+        effect_name = config.get("bot.banner_effect_type", "Beams")
 
     # try to use terminal effects if enabled and available
     if enable_effects:

--- a/src/cpu/logging/component.py
+++ b/src/cpu/logging/component.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from cpu.components.base import ComponentState, HealthStatus, RunnableComponent
 from cpu.logging.queue_handler import suppress_queue_logging
+from cpu.logging.rotation import CompressingRotatingFileHandler
 from cpu.logging.sanitizer import LogSanitizer
 from cpu.messaging.interfaces import MessageQueueInterface, QueueEmptyError
 from cpu.messaging.message import Message, MessageType
@@ -32,7 +33,7 @@ class LoggingComponent(RunnableComponent):
         super().__init__(name, config)
         self._queue = log_queue
         self._sanitizer = LogSanitizer()
-        self._file_handler: logging.FileHandler | None = None
+        self._file_handler: CompressingRotatingFileHandler | None = None
         self._logger: logging.Logger | None = None
 
     def initialize(self) -> None:
@@ -46,13 +47,19 @@ class LoggingComponent(RunnableComponent):
             "format",
             "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
+        max_bytes = self.config.get("max_bytes", 10 * 1024 * 1024)  # 10 MB
+        backup_count = self.config.get("backup_count", 5)
 
         # create log directory
         log_path = Path(log_file)
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # create file handler
-        self._file_handler = logging.FileHandler(log_file)
+        # create rotating file handler with compression
+        self._file_handler = CompressingRotatingFileHandler(
+            log_file,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+        )
         self._file_handler.setLevel(logging.DEBUG)
 
         # create formatter

--- a/src/cpu/logging/setup.py
+++ b/src/cpu/logging/setup.py
@@ -9,11 +9,8 @@ Early logging configuration before components start.
 from __future__ import annotations
 
 import logging
-import logging.handlers
-from pathlib import Path
 from typing import Any
 
-from cpu.config.config import Config
 from cpu.logging.queue_handler import QueueLoggingHandler
 from cpu.messaging.interfaces import MessageQueueInterface
 from cpu.messaging.message import Message
@@ -52,61 +49,6 @@ if False:  # pragma: no cover
         def trace(self, message: str, *args: Any, **kwargs: Any) -> None: ...
 
     logging.Logger.trace = _LoggerProtocol.trace
-
-def configure_logging(config: Config) -> None:
-    """
-    Configure Python logging before components start.
-
-    Args:
-        config: Configuration object
-    """
-    # get logging config
-    log_file = config.get("bot.logging.file", "logs/cpu.log")
-    log_level = config.get("bot.logging.level", "INFO")
-    log_format = config.get(
-        "bot.logging.format",
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    max_bytes = config.get("bot.logging.max_bytes", 10 * 1024 * 1024)  # 10MB
-    backup_count = config.get("bot.logging.backup_count", 5)
-
-    # create log directory
-    log_path = Path(log_file)
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # configure root logger
-    root_logger = logging.getLogger()
-    # handle TRACE as a special case since it's not in standard logging
-    if log_level.upper() == "TRACE":
-        root_logger.setLevel(TRACE)
-    else:
-        root_logger.setLevel(getattr(logging, log_level.upper()))
-
-    # create file handler with rotation
-    file_handler = logging.handlers.RotatingFileHandler(
-        log_file,
-        maxBytes=max_bytes,
-        backupCount=backup_count,
-    )
-    file_handler.setLevel(logging.DEBUG)  # handler accepts all, logger filters
-
-    # create formatter
-    formatter = logging.Formatter(log_format)
-    file_handler.setFormatter(formatter)
-
-    # add handler to root logger
-    root_logger.addHandler(file_handler)
-
-    # configure hierarchical loggers
-    loggers_config = config.get("bot.logging.loggers", {})
-    for logger_name, logger_level in loggers_config.items():
-        logger = logging.getLogger(logger_name)
-        # handle TRACE as a special case
-        if logger_level.upper() == "TRACE":
-            logger.setLevel(TRACE)
-        else:
-            logger.setLevel(getattr(logging, logger_level.upper()))
-
 
 def configure_queue_logging(
     log_queue: MessageQueueInterface[Message],

--- a/tests/integration/test_logging_integration.py
+++ b/tests/integration/test_logging_integration.py
@@ -19,7 +19,7 @@ from cpu.components.orchestrator import Orchestrator
 from cpu.config.config import Config
 from cpu.logging.decorators import trace_calls
 from cpu.logging.sanitizer import LogSanitizer
-from cpu.logging.setup import TRACE, configure_logging
+from cpu.logging.setup import TRACE, configure_queue_logging
 from cpu.messaging.message import Message, MessageType
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -74,14 +74,15 @@ bot:
 
         config = Config(config_file=config_file)
         config.load()
-        configure_logging(config)
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        configure_queue_logging(log_queue, level=logging.INFO)
 
-        # verify levels are set correctly
-        messaging_logger = logging.getLogger("cpu.messaging")
-        components_logger = logging.getLogger("cpu.components")
+        # per-module levels are set directly on child loggers
+        logging.getLogger("cpu.messaging").setLevel(logging.DEBUG)
+        logging.getLogger("cpu.components").setLevel(logging.WARNING)
 
-        assert messaging_logger.level == logging.DEBUG or messaging_logger.getEffectiveLevel() == logging.DEBUG
-        assert components_logger.level == logging.WARNING or components_logger.getEffectiveLevel() == logging.WARNING
+        assert logging.getLogger("cpu.messaging").level == logging.DEBUG
+        assert logging.getLogger("cpu.components").level == logging.WARNING
 
     def test_trace_decorator_overhead(self) -> None:
         """Ensure trace decorator doesn't significantly impact performance."""

--- a/tests/unit/test_logging_component.py
+++ b/tests/unit/test_logging_component.py
@@ -293,3 +293,42 @@ class TestLoggingComponent:
         component.initialize()
 
         assert logging.getLogger("cpu.logging").propagate is False
+
+    def test_uses_compressing_rotating_file_handler(self, tmp_path: Path) -> None:
+        """Test LoggingComponent uses CompressingRotatingFileHandler."""
+        from cpu.logging.rotation import CompressingRotatingFileHandler
+
+        log_file = tmp_path / "test.log"
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        component = LoggingComponent(
+            name="logger",
+            log_queue=queue,
+            config={"file": str(log_file), "level": "INFO"},
+        )
+        component.initialize()
+
+        assert isinstance(component._file_handler, CompressingRotatingFileHandler)
+
+    def test_rotation_config_applied(self, tmp_path: Path) -> None:
+        """Test max_bytes and backup_count are read from config."""
+        from cpu.logging.rotation import CompressingRotatingFileHandler
+
+        log_file = tmp_path / "test.log"
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        component = LoggingComponent(
+            name="logger",
+            log_queue=queue,
+            config={
+                "file": str(log_file),
+                "level": "INFO",
+                "max_bytes": 1024,
+                "backup_count": 3,
+            },
+        )
+        component.initialize()
+
+        assert isinstance(component._file_handler, CompressingRotatingFileHandler)
+        assert component._file_handler.maxBytes == 1024
+        assert component._file_handler.backupCount == 3

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -9,13 +9,11 @@ Tests for logging setup.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 import pytest
 
-from cpu.config.config import Config
 from cpu.logging.queue_handler import QueueLoggingHandler
-from cpu.logging.setup import TRACE, configure_logging, configure_queue_logging
+from cpu.logging.setup import TRACE, configure_queue_logging
 from cpu.messaging.message import Message, MessageType
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -76,116 +74,6 @@ class TestTraceLevel:
         assert len(caplog.records) == 2
         assert caplog.records[0].levelname == "TRACE"
         assert caplog.records[1].levelname == "DEBUG"
-
-
-class TestLoggingSetup:
-    """Test logging configuration."""
-
-    def test_configure_logging_creates_file_handler(self, tmp_path: Path) -> None:
-        """Test file handler is created."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: INFO
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        configure_logging(config)
-
-        root_logger = logging.getLogger()
-        # should have file handler
-        assert any(isinstance(handler, logging.FileHandler) for handler in root_logger.handlers)
-
-    def test_configure_logging_sets_levels(self, tmp_path: Path) -> None:
-        """Test logging level is set."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: DEBUG
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        configure_logging(config)
-
-        root_logger = logging.getLogger()
-        assert root_logger.level == logging.DEBUG
-
-    def test_configure_logging_hierarchical_loggers(self, tmp_path: Path) -> None:
-        """Test hierarchical logger levels."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: WARNING
-    loggers:
-      cpu.timer: DEBUG
-      cpu.job_manager: INFO
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        configure_logging(config)
-
-        timer_logger = logging.getLogger("cpu.timer")
-        job_logger = logging.getLogger("cpu.job_manager")
-
-        assert timer_logger.level == logging.DEBUG
-        assert job_logger.level == logging.INFO
-
-    def test_configure_logging_uses_format_from_config(self, tmp_path: Path) -> None:
-        """Test custom log format is applied."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: INFO
-    format: "%(levelname)s - %(message)s"
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        # clear existing handlers (pytest adds its own)
-        root_logger = logging.getLogger()
-        root_logger.handlers.clear()
-
-        configure_logging(config)
-
-        file_handlers = [handler for handler in root_logger.handlers if isinstance(handler, logging.FileHandler)]
-        assert len(file_handlers) > 0
-
-        formatter = file_handlers[0].formatter
-        assert formatter is not None
-        assert formatter._fmt == "%(levelname)s - %(message)s"
-
-    def test_configure_logging_with_trace_level(self, tmp_path: Path) -> None:
-        """Test TRACE level can be configured."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: TRACE
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        configure_logging(config)
-
-        root_logger = logging.getLogger()
-        assert root_logger.level == TRACE
 
 
 class TestConfigureQueueLogging:


### PR DESCRIPTION
- removes function
- removes unit tests for the function
- adjusts one integration test to use `configure_logging_queue()`
- uses `CompressingRotatingFileHandler` for log file
- set default banner effect to Beams
- only print some startup messages when log level is WARNING