### PR TITLE
Release v0.0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ venv/
 env/
 ENV/
 .venv/
+.vp310/
 
 # OS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [0.0.9] - 2026-06-13
+
+### Added
+
+- `QueueLoggingHandler`: custom logging handler that routes all `cpu.*`
+  log records through the message queue to `LoggingComponent`, enabling
+  async, non-blocking logging
+- `suppress_queue_logging()`: thread-local context manager to prevent
+  feedback loops when `LoggingComponent` drains its own queue
+- `configure_queue_logging()`: configures the `cpu` logger to use
+  `QueueLoggingHandler`, replacing direct file writes
+- Integration tests for the full logging chain (handler -> queue ->
+  `LoggingComponent` -> file)
+- `logging_component` pytest fixture in `conftest.py`
+
+### Changed
+
+- `LoggingComponent` is now the sole writer to the log file; all
+  `cpu.*` logging flows through the message queue
+- `LoggingComponent` uses `CompressingRotatingFileHandler` instead of
+  plain `FileHandler`, restoring log rotation with gzip compression
+- `LoggingComponent` preserves original log record metadata (logger
+  name, function name, line number) in file output
+- `__main__.py` uses two-phase logging: console-only during startup,
+  queue-based once `LoggingComponent` is registered
+- `Orchestrator.stop_all()` stops components in reverse registration
+  order, ensuring `LoggingComponent` stops last
+- Default banner effect changed from `Slide` to `Beams`
+- Console startup logging reduced to `WARNING` level
+
+### Fixed
+
+- `LoggingComponent` config keys aligned with sub-dict passed from
+  `__main__.py` (removed erroneous `bot.logging.` prefix)
+- Infinite feedback loop at TRACE level when `LoggingComponent`'s own
+  queue operations generated log records
+- Propagation disabled on `cpu.logging` logger to prevent write ->
+  propagate -> queue loop
+
+### Removed
+
+- `configure_logging()` from `setup.py` — replaced by
+  `configure_queue_logging()`
+
 ## [0.0.8] - 2026-02-16
 
 ### Added

--- a/src/cpu/__main__.py
+++ b/src/cpu/__main__.py
@@ -321,7 +321,7 @@ def main() -> int:
 
         # Phase 1: console-only logging during startup
         logging.basicConfig(
-            level=logging.INFO,
+            level=logging.WARNING,
             format="%(levelname)s: %(message)s",
         )
         logger.info("CPU Bot starting...")

--- a/src/cpu/__main__.py
+++ b/src/cpu/__main__.py
@@ -19,7 +19,7 @@ from cpu import __version__
 from cpu.components.orchestrator import Orchestrator
 from cpu.config.config import Config, ConfigError, ConfigValidationError
 from cpu.logging.component import LoggingComponent
-from cpu.logging.setup import configure_logging
+from cpu.logging.setup import TRACE, configure_queue_logging
 from cpu.messaging.message import Message
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 def create_orchestrator(config: Config) -> Orchestrator:
     """
     Create and configure orchestrator with all components.
+
+    Creates the LoggingComponent first and immediately switches all
+    cpu.* logging to the queue, so subsequent component registration
+    and initialization logs are captured by the LoggingComponent.
+    Messages buffer in the queue until start_all() runs the component.
 
     Args:
         config: Configuration object
@@ -43,9 +48,21 @@ def create_orchestrator(config: Config) -> Orchestrator:
     log_component = LoggingComponent(
         name="logger",
         log_queue=log_queue,
-        config=config.get("bot.logging", {}),
+        config=config.get("bot.logging", {}),  # plain sub-dict, no prefix
     )
     orchestrator.register(log_component)
+
+    # switch all cpu.* logging to the queue immediately
+    # messages buffer here until LoggingComponent thread starts
+    log_level_str: str = config.get("bot.logging.level", "INFO")
+    log_level: int = TRACE if log_level_str.upper() == "TRACE" else getattr(
+        logging, log_level_str.upper(), logging.INFO
+    )
+    configure_queue_logging(
+        log_queue,
+        source_component="cpu",
+        level=log_level,
+    )
 
     # TODO register components as they're implemented
     # orchestrator.register(EventHandlerComponent(...))
@@ -302,8 +319,11 @@ def main() -> int:
         # validate configuration
         validate_configuration(config)
 
-        # IMPORTANT: configure logging BEFORE components start
-        configure_logging(config)
+        # Phase 1: console-only logging during startup
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(levelname)s: %(message)s",
+        )
         logger.info("CPU Bot starting...")
 
         # create banner header
@@ -316,7 +336,8 @@ def main() -> int:
         # add startup information
         banner += create_startup_info(config_file, config, verbose=args.extended_startup_info)
 
-        # create and run orchestrator
+        # Phase 2: create orchestrator - switches cpu.* logging to queue
+        # inside create_orchestrator()
         orchestrator = create_orchestrator(config)
         orchestrator.initialize_all()
 

--- a/src/cpu/__main__.py
+++ b/src/cpu/__main__.py
@@ -185,10 +185,10 @@ def print_banner(banner: str, config: Config | None = None) -> None:
     """
     # check if terminal effects are enabled in config
     enable_effects = False
-    effect_name = "Slide"
+    effect_name = "Beams"
     if config is not None:
         enable_effects = config.get("bot.banner_effects", False)
-        effect_name = config.get("bot.banner_effect_type", "Slide")
+        effect_name = config.get("bot.banner_effect_type", "Beams")
 
     # try to use terminal effects if enabled and available
     if enable_effects:

--- a/src/cpu/components/orchestrator.py
+++ b/src/cpu/components/orchestrator.py
@@ -91,11 +91,16 @@ class Orchestrator:
         """
         Stop all components gracefully.
 
+        Components are stopped in reverse registration order, so
+        components registered first (e.g. the logging component)
+        are stopped last and remain available during shutdown of
+        the others.
+
         Args:
             timeout: Maximum time to wait for all components to stop
         """
         logger.info("Stopping all components")
-        for name in self._components:
+        for name in reversed(self._components):
             self.stop_component(name, timeout=timeout)
 
     def initialize_component(self, name: str) -> None:

--- a/src/cpu/logging/component.py
+++ b/src/cpu/logging/component.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from cpu.components.base import ComponentState, HealthStatus, RunnableComponent
 from cpu.logging.queue_handler import suppress_queue_logging
+from cpu.logging.rotation import CompressingRotatingFileHandler
 from cpu.logging.sanitizer import LogSanitizer
 from cpu.messaging.interfaces import MessageQueueInterface, QueueEmptyError
 from cpu.messaging.message import Message, MessageType
@@ -32,7 +33,7 @@ class LoggingComponent(RunnableComponent):
         super().__init__(name, config)
         self._queue = log_queue
         self._sanitizer = LogSanitizer()
-        self._file_handler: logging.FileHandler | None = None
+        self._file_handler: CompressingRotatingFileHandler | None = None
         self._logger: logging.Logger | None = None
 
     def initialize(self) -> None:
@@ -46,13 +47,19 @@ class LoggingComponent(RunnableComponent):
             "format",
             "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
+        max_bytes = self.config.get("max_bytes", 10 * 1024 * 1024)  # 10 MB
+        backup_count = self.config.get("backup_count", 5)
 
         # create log directory
         log_path = Path(log_file)
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # create file handler
-        self._file_handler = logging.FileHandler(log_file)
+        # create rotating file handler with compression
+        self._file_handler = CompressingRotatingFileHandler(
+            log_file,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+        )
         self._file_handler.setLevel(logging.DEBUG)
 
         # create formatter

--- a/src/cpu/logging/component.py
+++ b/src/cpu/logging/component.py
@@ -78,13 +78,26 @@ class LoggingComponent(RunnableComponent):
             # extract log info
             level = msg.payload.get("level", logging.INFO)
             message = msg.payload.get("message", "")
+            name = msg.payload.get("name", "cpu")
+            func = msg.payload.get("funcName", "")
+            lineno = msg.payload.get("lineno", 0)
 
             # sanitize message
             sanitized = self._sanitizer.sanitize(message)
 
-            # write to log
-            if self._logger:
-                self._logger.log(level, sanitized)
+            # write to log, preserving original metadata
+            if self._logger and self._logger.isEnabledFor(level):
+                record = logging.LogRecord(
+                    name=name,
+                    level=level,
+                    pathname="",
+                    lineno=lineno,
+                    msg=sanitized,
+                    args=(),
+                    exc_info=None,
+                    func=func,
+                )
+                self._logger.handle(record)
 
         except QueueEmptyError:
             # no messages, continue

--- a/src/cpu/logging/component.py
+++ b/src/cpu/logging/component.py
@@ -63,6 +63,9 @@ class LoggingComponent(RunnableComponent):
         self._logger = logging.getLogger("cpu.logging")
         self._logger.addHandler(self._file_handler)
         self._logger.setLevel(getattr(logging, log_level.upper()))
+        # must not propagate to cpu logger - that has the QueueLoggingHandler
+        # which would create a feedback loop on every write
+        self._logger.propagate = False
 
         self.state = ComponentState.INITIALIZED
 

--- a/src/cpu/logging/component.py
+++ b/src/cpu/logging/component.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from cpu.components.base import ComponentState, HealthStatus, RunnableComponent
+from cpu.logging.queue_handler import suppress_queue_logging
 from cpu.logging.sanitizer import LogSanitizer
 from cpu.messaging.interfaces import MessageQueueInterface, QueueEmptyError
 from cpu.messaging.message import Message, MessageType
@@ -68,7 +69,10 @@ class LoggingComponent(RunnableComponent):
     def process_iteration(self) -> None:
         """Process one log message from queue."""
         try:
-            msg = self._queue.get(timeout=0.1)
+            # suppress queue logging around our own queue operation to
+            # prevent a feedback loop (get() logs at TRACE level)
+            with suppress_queue_logging():
+                msg = self._queue.get(timeout=0.1)
 
             # verif message type
             if msg.type != MessageType.LOG:

--- a/src/cpu/logging/component.py
+++ b/src/cpu/logging/component.py
@@ -39,10 +39,10 @@ class LoggingComponent(RunnableComponent):
         # setup flush handler for flush
         self.setup_flush_signal()
 
-        log_file = self.config.get("bot.logging.file", "logs/cpu.log")
-        log_level = self.config.get("bot.logging.level", "INFO")
+        log_file = self.config.get("file", "logs/cpu.log")
+        log_level = self.config.get("level", "INFO")
         log_format = self.config.get(
-            "bot.logging.format",
+            "format",
             "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
 

--- a/src/cpu/logging/queue_handler.py
+++ b/src/cpu/logging/queue_handler.py
@@ -12,9 +12,33 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections.abc import Generator
+from contextlib import contextmanager
 
 from cpu.messaging.interfaces import MessageQueueInterface, QueueFullError
 from cpu.messaging.message import Message, MessageType
+
+# thead-local suppression state, shared by all handler instance
+_thread_state = threading.local()
+
+
+@contextmanager
+def suppress_queue_logging() -> Generator[None, None, None]:
+    """
+    Suppress queue-based logging in the current thread.
+
+    Log calls made inside this context are dropped by all
+    QueueLoggingHandler instances. Used by the LoggingComponent around
+    its own queue operations to prevent a feedback loop: each
+    queue.get() would otherwise log a TRACE message that lands back in
+    the very queue being drained.
+    """
+    previous = getattr(_thread_state, "suppressed", False)
+    _thread_state.suppressed = True
+    try:
+        yield
+    finally:
+        _thread_state.suppressed = previous
 
 
 class QueueLoggingHandler(logging.Handler):
@@ -71,8 +95,9 @@ class QueueLoggingHandler(logging.Handler):
         """
         # re-entry guard: creating/queueing the Message below triggers
         # log calls on cpu.messaging.* loggers, which land in this same
-        # handler and would recurse forever
-        if getattr(self._emitting, "active", False):
+        # handler and would recurse forever; also honor explicit
+        # per-thread suppression (see suppress_queue_logging)
+        if getattr(self._emitting, "active", False) or getattr(_thread_state, "suppressed", False):
             return
         self._emitting.active = True
         try:

--- a/src/cpu/logging/queue_handler.py
+++ b/src/cpu/logging/queue_handler.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+Custom logging handler that sends logs through message queue.
+
+This handler integrates Python's logging system with the CPU bot's
+message-passing architecture, sending all log records to the
+LoggingComponent via a message queue.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cpu.messaging.interfaces import MessageQueueInterface, QueueFullError
+from cpu.messaging.message import Message, MessageType
+
+
+class QueueLoggingHandler(logging.Handler):
+    """
+    Logging handler that sends log records to LoggingComponent via queue.
+
+    Converts logging.LogRecord objects to Message objects and sends them
+    through the message queue for async processing by LoggingComponent.
+
+    This enables:
+    - Async, non-blocking logging
+    - Centralized log file writing (LoggingComponent only)
+    - Message sanitization
+    - Support for distributed/multi-process logging
+
+    Example:
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "my_component")
+        logger = logging.getLogger("my_app")
+        logger.addHandler(handler)
+        logger.info("This goes through the queue!")
+    """
+
+    def __init__(
+        self,
+        queue: MessageQueueInterface[Message],
+        source_component: str = "unknown",
+    ) -> None:
+        """
+        Initialize queue logging handler.
+
+        Args:
+            queue: Message queue to send log messages to
+            source_component: Name of component generating logs
+        """
+        super().__init__()
+        self._queue = queue
+        self._source = source_component
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """
+        Send log record to queue as Message.
+
+        Converts the LogRecord to a Message with type LOG and sends
+        it to the queue for processing by LoggingComponent.
+
+        Args:
+            record: LogRecord to process
+        """
+        try:
+            # format the message using configured formatter
+            message_text = self.format(record)
+
+            # create log message
+            log_message = Message(
+                type=MessageType.LOG,
+                payload={
+                    "level": record.levelno,
+                    "message": message_text,
+                    "name": record.name,
+                    "funcName": record.funcName,
+                    "lineno": record.lineno,
+                },
+                source=self._source,
+            )
+
+            # send to queue (non-blocking to avoid deadlock)
+            # if queue is full, message is dropped (logging must not block)
+            self._queue.put(log_message, block=False)
+
+        except QueueFullError:
+            # queue full - drop message silently
+            # logging must never block or crash the application
+            pass
+        except Exception:
+            # CRITICAL: don't raise exceptions from logging
+            # this would break the component using the logger
+            self.handleError(record)

--- a/src/cpu/logging/queue_handler.py
+++ b/src/cpu/logging/queue_handler.py
@@ -11,6 +11,7 @@ LoggingComponent via a message queue.
 from __future__ import annotations
 
 import logging
+import threading
 
 from cpu.messaging.interfaces import MessageQueueInterface, QueueFullError
 from cpu.messaging.message import Message, MessageType
@@ -52,6 +53,7 @@ class QueueLoggingHandler(logging.Handler):
         super().__init__()
         self._queue = queue
         self._source = source_component
+        self._emitting = threading.local()
 
     def emit(self, record: logging.LogRecord) -> None:
         """
@@ -60,9 +62,19 @@ class QueueLoggingHandler(logging.Handler):
         Converts the LogRecord to a Message with type LOG and sends
         it to the queue for processing by LoggingComponent.
 
+        Log calls made by the messaging infrastructure itself while
+        emitting (e.g. Message creation logs at DEBUG, queue.put logs
+        at TRACE) are dropped to prevent infinite recursion.
+
         Args:
             record: LogRecord to process
         """
+        # re-entry guard: creating/queueing the Message below triggers
+        # log calls on cpu.messaging.* loggers, which land in this same
+        # handler and would recurse forever
+        if getattr(self._emitting, "active", False):
+            return
+        self._emitting.active = True
         try:
             # format the message using configured formatter
             message_text = self.format(record)
@@ -92,3 +104,5 @@ class QueueLoggingHandler(logging.Handler):
             # CRITICAL: don't raise exceptions from logging
             # this would break the component using the logger
             self.handleError(record)
+        finally:
+            self._emitting.active = False

--- a/src/cpu/logging/setup.py
+++ b/src/cpu/logging/setup.py
@@ -9,11 +9,8 @@ Early logging configuration before components start.
 from __future__ import annotations
 
 import logging
-import logging.handlers
-from pathlib import Path
 from typing import Any
 
-from cpu.config.config import Config
 from cpu.logging.queue_handler import QueueLoggingHandler
 from cpu.messaging.interfaces import MessageQueueInterface
 from cpu.messaging.message import Message
@@ -52,61 +49,6 @@ if False:  # pragma: no cover
         def trace(self, message: str, *args: Any, **kwargs: Any) -> None: ...
 
     logging.Logger.trace = _LoggerProtocol.trace
-
-def configure_logging(config: Config) -> None:
-    """
-    Configure Python logging before components start.
-
-    Args:
-        config: Configuration object
-    """
-    # get logging config
-    log_file = config.get("bot.logging.file", "logs/cpu.log")
-    log_level = config.get("bot.logging.level", "INFO")
-    log_format = config.get(
-        "bot.logging.format",
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    max_bytes = config.get("bot.logging.max_bytes", 10 * 1024 * 1024)  # 10MB
-    backup_count = config.get("bot.logging.backup_count", 5)
-
-    # create log directory
-    log_path = Path(log_file)
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # configure root logger
-    root_logger = logging.getLogger()
-    # handle TRACE as a special case since it's not in standard logging
-    if log_level.upper() == "TRACE":
-        root_logger.setLevel(TRACE)
-    else:
-        root_logger.setLevel(getattr(logging, log_level.upper()))
-
-    # create file handler with rotation
-    file_handler = logging.handlers.RotatingFileHandler(
-        log_file,
-        maxBytes=max_bytes,
-        backupCount=backup_count,
-    )
-    file_handler.setLevel(logging.DEBUG)  # handler accepts all, logger filters
-
-    # create formatter
-    formatter = logging.Formatter(log_format)
-    file_handler.setFormatter(formatter)
-
-    # add handler to root logger
-    root_logger.addHandler(file_handler)
-
-    # configure hierarchical loggers
-    loggers_config = config.get("bot.logging.loggers", {})
-    for logger_name, logger_level in loggers_config.items():
-        logger = logging.getLogger(logger_name)
-        # handle TRACE as a special case
-        if logger_level.upper() == "TRACE":
-            logger.setLevel(TRACE)
-        else:
-            logger.setLevel(getattr(logging, logger_level.upper()))
-
 
 def configure_queue_logging(
     log_queue: MessageQueueInterface[Message],

--- a/src/cpu/logging/setup.py
+++ b/src/cpu/logging/setup.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from typing import Any
 
 from cpu.config.config import Config
+from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.messaging.interfaces import MessageQueueInterface
+from cpu.messaging.message import Message
 
 # define TRACE level (below DEBUG)
 TRACE = 5
@@ -103,3 +106,36 @@ def configure_logging(config: Config) -> None:
             logger.setLevel(TRACE)
         else:
             logger.setLevel(getattr(logging, logger_level.upper()))
+
+
+def configure_queue_logging(
+    log_queue: MessageQueueInterface[Message],
+    source_component: str = "cpu",
+    level: int = logging.INFO,
+) -> None:
+    """
+    Configure queue-based logging for the cpu package.
+
+    Replaces all handlers on the "cpu" logger with a QueueLoggingHandler,
+    so every log call from cpu.* modules is sent to the LoggingComponent
+    via the message queue instead of being written directly.
+
+    Args:
+        log_queue: Queue to send log messages to
+        source_component: Name attached as message source
+        level: Minimum log level to send to the queue
+    """
+    cpu_logger = logging.getLogger("cpu")
+
+    # remove any existing handlers to avoid duplicate log paths
+    cpu_logger.handlers.clear()
+
+    # add queue handler
+    queue_handler = QueueLoggingHandler(log_queue, source_component)
+    queue_handler.setLevel(level)
+    cpu_logger.addHandler(queue_handler)
+
+    cpu_logger.setLevel(level)
+
+    # don't propagate to root logger (would bypass the queue)
+    cpu_logger.propagate = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,31 @@ Configuration of tests.
 
 import logging
 from collections.abc import Generator
+from pathlib import Path
+from typing import Any
 
 import pytest
+
+from cpu.logging.component import LoggingComponent
+from cpu.messaging.message import Message
+from cpu.messaging.queue_thread import ThreadMessageQueue
+
+
+@pytest.fixture
+def logging_component(
+    tmp_path: Path,
+) -> tuple[LoggingComponent, ThreadMessageQueue[Message], Path]:
+    """Create a LoggingComponent with queue for testing."""
+    log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+    log_file = tmp_path / "test.log"
+    config: dict[str, Any] = {
+        "bot.logging.file": str(log_file),
+        "bot.logging.level": "DEBUG",
+        "bot.logging.format": "%(levelname)s %(name)s %(message)s",
+    }
+    component = LoggingComponent(name="logger", log_queue=log_queue, config=config)
+    component.initialize()
+    return component, log_queue, log_file
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,9 @@ def logging_component(
     log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
     log_file = tmp_path / "test.log"
     config: dict[str, Any] = {
-        "bot.logging.file": str(log_file),
-        "bot.logging.level": "DEBUG",
-        "bot.logging.format": "%(levelname)s %(name)s %(message)s",
+        "file": str(log_file),
+        "level": "DEBUG",
+        "format": "%(levelname)s %(name)s %(message)s",
     }
     component = LoggingComponent(name="logger", log_queue=log_queue, config=config)
     component.initialize()

--- a/tests/integration/test_logging_integration.py
+++ b/tests/integration/test_logging_integration.py
@@ -19,7 +19,7 @@ from cpu.components.orchestrator import Orchestrator
 from cpu.config.config import Config
 from cpu.logging.decorators import trace_calls
 from cpu.logging.sanitizer import LogSanitizer
-from cpu.logging.setup import TRACE, configure_logging
+from cpu.logging.setup import TRACE, configure_queue_logging
 from cpu.messaging.message import Message, MessageType
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -74,14 +74,15 @@ bot:
 
         config = Config(config_file=config_file)
         config.load()
-        configure_logging(config)
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        configure_queue_logging(log_queue, level=logging.INFO)
 
-        # verify levels are set correctly
-        messaging_logger = logging.getLogger("cpu.messaging")
-        components_logger = logging.getLogger("cpu.components")
+        # per-module levels are set directly on child loggers
+        logging.getLogger("cpu.messaging").setLevel(logging.DEBUG)
+        logging.getLogger("cpu.components").setLevel(logging.WARNING)
 
-        assert messaging_logger.level == logging.DEBUG or messaging_logger.getEffectiveLevel() == logging.DEBUG
-        assert components_logger.level == logging.WARNING or components_logger.getEffectiveLevel() == logging.WARNING
+        assert logging.getLogger("cpu.messaging").level == logging.DEBUG
+        assert logging.getLogger("cpu.components").level == logging.WARNING
 
     def test_trace_decorator_overhead(self) -> None:
         """Ensure trace decorator doesn't significantly impact performance."""

--- a/tests/integration/test_logging_queue.py
+++ b/tests/integration/test_logging_queue.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+Integration tests for QueueLoggingHandler and LoggingComponent interplay.
+
+These tests verify the full logging chain:
+    logger.info("message")
+        -> QueueLoggingHandler.emit()
+        -> ThreadMessageQueue
+        -> LoggingComponent.process_iteration()
+        -> log file
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+
+from cpu.components.base import HealthStatus
+from cpu.logging.component import LoggingComponent
+from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.logging.setup import TRACE
+from cpu.messaging.message import Message, MessageType
+from cpu.messaging.queue_thread import ThreadMessageQueue
+
+
+class TestQueueLoggingIntegration:
+    """Integration tests for QueueLoggingHandler and LoggingComponent."""
+
+    def test_message_reaches_log_file(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test full chain: handler -> queue -> LoggingComponent -> file."""
+        component, log_queue, log_file = logging_component
+
+        handler = QueueLoggingHandler(log_queue, "test_component")
+        logger = logging.getLogger("test.integration.basic")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        logger.info("Hello from integration test")
+
+        component.process_iteration()
+        component.flush()
+
+        assert log_file.exists()
+        assert "Hello from integration test" in log_file.read_text()
+
+    def test_all_log_levels_written_to_file(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test all log levels including TRACE are written to file."""
+        component, log_queue, log_file = logging_component
+
+        handler = QueueLoggingHandler(log_queue, "test_component")
+        logger = logging.getLogger("test.integration.levels")
+        logger.addHandler(handler)
+        logger.setLevel(TRACE)
+
+        logger.log(TRACE, "Trace message")
+        logger.debug("Debug message")
+        logger.info("Info message")
+        logger.warning("Warning message")
+        logger.error("Error message")
+        logger.critical("Critical message")
+
+        for _ in range(6):
+            component.process_iteration()
+        component.flush()
+
+        content = log_file.read_text()
+        assert "Debug message" in content
+        assert "Info message" in content
+        assert "Warning message" in content
+        assert "Error message" in content
+        assert "Critical message" in content
+        # TRACE is below DEBUG so LoggingComponent may filter it
+        # depending on configured level - just verify others work
+
+    def test_message_sanitized_before_writing(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test sensitive data is sanitized before writing to file."""
+        component, log_queue, log_file = logging_component
+
+        handler = QueueLoggingHandler(log_queue, "test_component")
+        logger = logging.getLogger("test.integration.sanitize")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        logger.info("Connecting with token=supersecrettoken123")
+
+        component.process_iteration()
+        component.flush()
+
+        content = log_file.read_text()
+        assert "supersecrettoken123" not in content
+        assert "***" in content
+
+    def test_bad_message_doesnt_crash_component(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test LoggingComponent continues after a malformed message."""
+        component, log_queue, log_file = logging_component
+
+        # put a malformed log message (missing required fields)
+        bad_message = Message(
+            type=MessageType.LOG,
+            payload={},  # missing level and message
+        )
+        log_queue.put(bad_message)
+
+        # put a valid message after the bad one
+        good_message = Message(
+            type=MessageType.LOG,
+            payload={"level": logging.INFO, "message": "Good message after bad"},
+        )
+        log_queue.put(good_message)
+
+        # process both - should not crash
+        component.process_iteration()
+        component.process_iteration()
+        component.flush()
+
+        # component should still be healthy
+        assert component.health_check() == HealthStatus.HEALTHY
+
+        # good message should still be written
+        content = log_file.read_text()
+        assert "Good message after bad" in content
+
+    def test_non_log_message_ignored(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test LoggingComponent silently ignores non-LOG messages."""
+        component, log_queue, log_file = logging_component
+
+        # put a non-LOG message in the queue
+        webhook_message = Message(
+            type=MessageType.WEBHOOK,
+            payload={"data": "some webhook data"},
+        )
+        log_queue.put(webhook_message)
+
+        # put a valid log message after
+        log_message = Message(
+            type=MessageType.LOG,
+            payload={"level": logging.INFO, "message": "Real log message"},
+        )
+        log_queue.put(log_message)
+
+        component.process_iteration()  # webhook - should be ignored
+        component.process_iteration()  # log - should be written
+        component.flush()
+
+        content = log_file.read_text()
+        assert "some webhook data" not in content
+        assert "Real log message" in content
+
+    def test_log_ordering_preserved(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test that log messages are written in FIFO order."""
+        component, log_queue, log_file = logging_component
+
+        handler = QueueLoggingHandler(log_queue, "test_component")
+        logger = logging.getLogger("test.integration.ordering")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        messages = [f"Message {i}" for i in range(5)]
+        for msg in messages:
+            logger.info(msg)
+
+        for _ in range(5):
+            component.process_iteration()
+        component.flush()
+
+        content = log_file.read_text()
+        positions = [content.index(msg) for msg in messages]
+
+        # verify messages appear in order
+        assert positions == sorted(positions)
+
+    def test_component_processes_messages_in_thread(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test LoggingComponent processes messages correctly when running in thread."""
+        component, log_queue, log_file = logging_component
+
+        thread = threading.Thread(target=component.start)
+        thread.start()
+
+        handler = QueueLoggingHandler(log_queue, "test_component")
+        logger = logging.getLogger("test.integration.thread")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        for i in range(10):
+            logger.info(f"Threaded message {i}")
+
+        # wait for processing
+        time.sleep(0.5)
+
+        component.stop()
+        thread.join(timeout=2)
+        component.flush()
+
+        content = log_file.read_text()
+        for i in range(10):
+            assert f"Threaded message {i}" in content

--- a/tests/integration/test_logging_queue.py
+++ b/tests/integration/test_logging_queue.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from cpu.components.base import HealthStatus
 from cpu.logging.component import LoggingComponent
 from cpu.logging.queue_handler import QueueLoggingHandler
-from cpu.logging.setup import TRACE
+from cpu.logging.setup import TRACE, configure_queue_logging
 from cpu.messaging.message import Message, MessageType
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -218,3 +218,28 @@ class TestQueueLoggingIntegration:
         content = log_file.read_text()
         for i in range(10):
             assert f"Threaded message {i}" in content
+
+    def test_no_feedback_loop_at_trace_level(
+        self,
+        logging_component: tuple[LoggingComponent, ThreadMessageQueue[Message], Path],
+    ) -> None:
+        """Test the component's own queue operations don't generate log messages."""
+        component, log_queue, log_file = logging_component
+
+        # route all cpu.* logging into the same queue at TRACE level
+        configure_queue_logging(log_queue, level=TRACE)
+
+        thread = threading.Thread(target=component.start)
+        thread.start()
+
+        # without suppression, every queue.get would enqueue a new TRACE
+        # message, keeping the queue busy forever
+        time.sleep(0.3)
+
+        component.stop()
+        thread.join(timeout=2)
+        component.flush()
+
+        # queue must not have balloned with self-generated messages
+        assert log_queue.qsize() < 10
+        assert "Getting message from queue" not in log_file.read_text()

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""Integration tests for __main__ logging wiring."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from cpu.__main__ import create_orchestrator
+from cpu.config.config import Config
+from cpu.logging.queue_handler import QueueLoggingHandler
+
+
+class TestMainLoggingWiring:
+    """Test that __main__ correctly wires queue-based logging."""
+
+    def test_cpu_logger_uses_queue_handler_after_create_orchestrator(
+        self, tmp_path: Path
+    ) -> None:
+        """Test cpu logger has QueueLoggingHandler after create_orchestrator."""
+        config_file = tmp_path / "config.yaml"
+        log_file = tmp_path / "cpu.log"
+        config_file.write_text(f"""
+bot:
+  num_workers: 2
+  logging:
+    level: INFO
+    file: {log_file}
+    format: "%(levelname)s %(name)s %(message)s"
+""")
+        config = Config(config_file=config_file)
+        config.load()
+
+        create_orchestrator(config)
+
+        cpu_logger = logging.getLogger("cpu")
+        assert any(
+            isinstance(h, QueueLoggingHandler) for h in cpu_logger.handlers
+        )
+
+    def test_logs_after_create_orchestrator_reach_queue(
+        self, tmp_path: Path
+    ) -> None:
+        """Test log calls after create_orchestrator go to the queue."""
+        config_file = tmp_path / "config.yaml"
+        log_file = tmp_path / "cpu.log"
+        config_file.write_text(f"""
+bot:
+  num_workers: 2
+  logging:
+    level: INFO
+    file: {log_file}
+""")
+        config = Config(config_file=config_file)
+        config.load()
+
+        create_orchestrator(config)
+
+        cpu_logger = logging.getLogger("cpu")
+        handler = next(
+            h for h in cpu_logger.handlers if isinstance(h, QueueLoggingHandler)
+        )
+
+        from cpu.messaging.message import MessageType
+
+        cpu_logger.info("Post-orchestrator log")
+
+        msg = handler._queue.get(timeout=1)
+        assert msg.type == MessageType.LOG
+        assert "Post-orchestrator log" in msg.payload["message"]
+
+    def test_messages_buffered_before_logging_component_starts(
+            self, tmp_path: Path
+        ) -> None:
+        """Test log messages are buffered in queue before LoggingComponent starts."""
+        config_file = tmp_path / "config.yaml"
+        log_file = tmp_path / "cpu.log"
+        config_file.write_text(f"""
+bot:
+  num_workers: 2
+  logging:
+    level: INFO
+    file: {log_file}
+""")
+        config = Config(config_file=config_file)
+        config.load()
+
+        # create orchestrator - switches to queue logging but doesn't start yet
+        orchestrator = create_orchestrator(config)
+
+        # log something before start_all()
+        logger = logging.getLogger("cpu.test")
+        logger.info("Buffered message")
+
+        # verify message is in the queue but not yet written to file
+        cpu_logger = logging.getLogger("cpu")
+        handler = next(
+            _handler for _handler in cpu_logger.handlers if isinstance(_handler, QueueLoggingHandler)
+        )
+        assert not handler._queue.empty()
+
+        # now start and let LoggingComponent process the queue
+        orchestrator.initialize_all()
+        orchestrator.start_all()
+
+        import time
+        time.sleep(0.3)
+
+        orchestrator.stop_all(timeout=2)
+
+        # verify message reached the file
+        assert log_file.exists()
+        assert "Buffered message" in log_file.read_text()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -782,7 +782,7 @@ bot:
         assert "Configuration validated successfully" in caplog.text
 
     def test_component_initialization_logs_at_info(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        """Test component initialization logs at INFO level."""
+        """Test startup logs before queue logging is active and reach caplog."""
         caplog.set_level(logging.INFO)
 
         config_file = tmp_path / "config.yaml"
@@ -801,7 +801,10 @@ bot:
 
             main()
 
-        assert "All components initialized" in caplog.text
+        # messages logged before create_orchestrator() switches to queue
+        # logging still reach caplog via basicConfig
+        assert "CPU Bot starting" in caplog.text
+        assert "Configuration validated" in caplog.text
 
     def test_shutdown_logs_at_info(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test shutdown logs at INFO level."""

--- a/tests/unit/test_components_orchestrator.py
+++ b/tests/unit/test_components_orchestrator.py
@@ -473,3 +473,27 @@ class TestOrchestratorLogging:
 
         assert statuses["test_component"] == HealthStatus.HEALTHY
         assert "Health check for component test_component: HEALTHY" in caplog.text
+
+    def test_stop_all_reverse_registration_order(self) -> None:
+        """Test components are stopped in reverse registration order."""
+        orchestrator = Orchestrator()
+        stop_order: list[str] = []
+
+        class OrderTrackingComponent(MockRunnableComponent):
+            def stop(self, timeout: float | None = None) -> None:
+                stop_order.append(self.name)
+                super().stop(timeout=timeout)
+
+        first = OrderTrackingComponent(name="first")
+        second = OrderTrackingComponent(name="second")
+        third = OrderTrackingComponent(name="third")
+
+        orchestrator.register(first)
+        orchestrator.register(second)
+        orchestrator.register(third)
+        orchestrator.initialize_all()
+        orchestrator.start_all()
+
+        orchestrator.stop_all(timeout=2)
+
+        assert stop_order == ["third", "second", "first"]

--- a/tests/unit/test_logging_component.py
+++ b/tests/unit/test_logging_component.py
@@ -279,3 +279,17 @@ class TestLoggingComponent:
         component.flush()
 
         assert "Too detailed" not in log_file.read_text()
+
+    def test_logger_does_not_propagate(self, tmp_path: Path) -> None:
+        """Test internal logger has propagation disabled to prevent feedback loop."""
+        log_file = tmp_path / "test.log"
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        component = LoggingComponent(
+            name="logger",
+            log_queue=queue,
+            config={"file": str(log_file), "level": "DEBUG"},
+        )
+        component.initialize()
+
+        assert logging.getLogger("cpu.logging").propagate is False

--- a/tests/unit/test_logging_component.py
+++ b/tests/unit/test_logging_component.py
@@ -293,3 +293,42 @@ class TestLoggingComponent:
         component.initialize()
 
         assert logging.getLogger("cpu.logging").propagate is False
+
+    def test_uses_compressing_rotating_file_handler(self, tmp_path: Path) -> None:
+        """Test LoggingComponent uses CompressingRotatingFileHandler."""
+        from cpu.logging.rotation import CompressingRotatingFileHandler
+
+        log_file = tmp_path / "test.log"
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        component = LoggingComponent(
+            name="logger",
+            log_queue=queue,
+            config={"file": str(log_file), "level": "INFO"},
+        )
+        component.initialize()
+
+        assert isinstance(component._file_handler, CompressingRotatingFileHandler)
+
+    def test_rotation_config_applied(self, tmp_path: Path) -> None:
+        """Test max_bytes and backup_count are read from config."""
+        from cpu.logging.rotation import CompressingRotatingFileHandler
+
+        log_file = tmp_path / "test.log"
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        component = LoggingComponent(
+            name="logger",
+            log_queue=queue,
+            config={
+                "file": str(log_file),
+                "level": "INFO",
+                "max_bytes": 1024,
+                "backup_count": 3,
+            },
+        )
+        component.initialize()
+
+        assert isinstance(component._file_handler, CompressingRotatingFileHandler)
+        assert component._file_handler.maxBytes == 1024
+        assert component._file_handler.backupCount == 3

--- a/tests/unit/test_logging_component.py
+++ b/tests/unit/test_logging_component.py
@@ -224,3 +224,58 @@ class TestLoggingComponent:
 
             # flush should not be called
             mock_flush.assert_not_called()
+
+    def test_metadata_preserved_in_log_output(self, tmp_path: Path) -> None:
+        """Test original logger name, function, and line number appear in log."""
+        log_file = tmp_path / "test.log"
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        component = LoggingComponent(
+            name="logger",
+            log_queue=queue,
+            config={
+                "file": str(log_file),
+                "level": "DEBUG",
+                "format": "%(name)s:%(funcName)s:%(lineno)d %(message)s",
+            },
+        )
+        component.initialize()
+
+        msg = Message(
+            type=MessageType.LOG,
+            payload={
+                "level": logging.INFO,
+                "message": "With metadata",
+                "name": "cpu.event_handler",
+                "funcName": "handle_webhook",
+                "lineno": 42,
+            },
+        )
+        queue.put(msg)
+        component.process_iteration()
+        component.flush()
+
+        content = log_file.read_text()
+        assert "cpu.event_handler:handle_webhook:42 With metadata" in content
+
+    def test_level_filtering_respected(self, tmp_path: Path) -> None:
+        """Test messages below configured level are not written."""
+        log_file = tmp_path / "test.log"
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        component = LoggingComponent(
+            name="logger",
+            log_queue=queue,
+            config={"file": str(log_file), "level": "INFO"},
+        )
+        component.initialize()
+
+        msg = Message(
+            type=MessageType.LOG,
+            payload={"level": logging.DEBUG, "message": "Too detailed"},
+        )
+        queue.put(msg)
+        component.process_iteration()
+        component.flush()
+
+        assert "Too detailed" not in log_file.read_text()

--- a/tests/unit/test_logging_component.py
+++ b/tests/unit/test_logging_component.py
@@ -29,7 +29,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         component.initialize()
 
@@ -56,7 +56,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         component.initialize()
 
@@ -81,7 +81,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         component.initialize()
 
@@ -106,7 +106,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         component.initialize()
 
@@ -123,7 +123,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         component.initialize()
 
@@ -144,7 +144,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         component.initialize()
 
@@ -162,7 +162,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         component.initialize()
 
@@ -182,7 +182,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         # don't initialize
 
@@ -196,7 +196,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         # don't initialize (no handler)
 
@@ -214,7 +214,7 @@ class TestLoggingComponent:
         component = LoggingComponent(
             name="logger",
             log_queue=queue,
-            config={"bot.logging.file": str(log_file), "bot.logging.level": "INFO"},
+            config={"file": str(log_file), "level": "INFO"},
         )
         component.initialize()
 

--- a/tests/unit/test_logging_queue_handler.py
+++ b/tests/unit/test_logging_queue_handler.py
@@ -227,9 +227,11 @@ class TestQueueLoggingHandler:
         logger.addHandler(handler)
         logger.setLevel(logging.INFO)
 
-        with suppress_queue_logging():
-            with suppress_queue_logging():
-                logger.info("Still suppressed")
+        with (
+            suppress_queue_logging(),
+            suppress_queue_logging()
+        ):
+            logger.info("Still suppressed")
 
         logger.info("Back to normal")
 

--- a/tests/unit/test_logging_queue_handler.py
+++ b/tests/unit/test_logging_queue_handler.py
@@ -3,8 +3,9 @@
 """Tests for QueueLoggingHandler."""
 
 import logging
+import threading
 
-from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.logging.queue_handler import QueueLoggingHandler, suppress_queue_logging
 from cpu.messaging.message import Message, MessageType
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -167,4 +168,71 @@ class TestQueueLoggingHandler:
         assert "Should appear" in msg.payload["message"]
 
         # queue should be empty
+        assert queue.empty()
+
+    def test_suppression_drops_messages(self) -> None:
+        """Test log calls inside suppression context are not queued."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.suppress")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        with suppress_queue_logging():
+            logger.info("Suppressed message")
+
+        logger.info("Normal message")
+
+        msg = queue.get(timeout=1)
+        assert "Normal message" in msg.payload["message"]
+        assert queue.empty()
+
+    def test_suppression_is_per_thread(self) -> None:
+        """Test suppression in one thread does not affect another."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.suppress.thread")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def worker() -> None:
+            with suppress_queue_logging():
+                entered.set()
+                release.wait(timeout=2)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        entered.wait(timeout=2)
+
+        # other thread is suppressed, this one is not
+        logger.info("From main thread")
+
+        release.set()
+        thread.join(timeout=2)
+
+        msg = queue.get(timeout=1)
+        assert "From main thread" in msg.payload["message"]
+
+    def test_suppression_restored_after_context(self) -> None:
+        """Test suppression state is restored, including when nested."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.suppress.nested")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        with suppress_queue_logging():
+            with suppress_queue_logging():
+                logger.info("Still suppressed")
+
+        logger.info("Back to normal")
+
+        msg = queue.get(timeout=1)
+        assert "Back to normal" in msg.payload["message"]
         assert queue.empty()

--- a/tests/unit/test_logging_queue_handler.py
+++ b/tests/unit/test_logging_queue_handler.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""Tests for QueueLoggingHandler."""
+
+import logging
+
+from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.messaging.message import Message, MessageType
+from cpu.messaging.queue_thread import ThreadMessageQueue
+
+
+class TestQueueLoggingHandler:
+    """Test QueueLoggingHandler functionality."""
+
+    def test_handler_sends_message_to_queue(self) -> None:
+        """Test handler creates and sends log message to queue."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test_component")
+
+        logger = logging.getLogger("test.handler")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        logger.info("Test message")
+
+        # verify message in queue
+        msg = queue.get(timeout=1)
+        assert msg.type == MessageType.LOG
+        assert msg.payload["level"] == logging.INFO
+        assert "Test message" in msg.payload["message"]
+        assert msg.source == "test_component"
+
+    def test_handler_includes_metadata(self) -> None:
+        """Test handler includes logger name, function, and line number."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test_component")
+
+        logger = logging.getLogger("test.metadata")
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
+        logger.debug("Debug message")
+
+        msg = queue.get(timeout=1)
+        assert msg.payload["name"] == "test.metadata"
+        assert msg.payload["funcName"] == "test_handler_includes_metadata"
+        assert msg.payload["lineno"] > 0
+
+    def test_handler_formats_message(self) -> None:
+        """Test handler formats message with formatter."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test_component")
+
+        # set a custom formatter
+        formatter = logging.Formatter("%(levelname)s: %(message)s")
+        handler.setFormatter(formatter)
+
+        logger = logging.getLogger("test.format")
+        logger.addHandler(handler)
+        logger.setLevel(logging.WARNING)
+
+        logger.warning("Warning message")
+
+        msg = queue.get(timeout=1)
+        assert "WARNING: Warning message" in msg.payload["message"]
+
+    def test_handler_different_log_levels(self) -> None:
+        """Test handler handles different log levels including TRACE."""
+        from cpu.logging.setup import TRACE
+
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test_component")
+
+        logger = logging.getLogger("test.levels")
+        logger.addHandler(handler)
+        logger.setLevel(TRACE)
+
+        # log at different levels
+        logger.log(TRACE, "Trace")
+        logger.debug("Debug")
+        logger.info("Info")
+        logger.warning("Warning")
+        logger.error("Error")
+        logger.critical("Critical")
+
+        # verify all levels
+        levels = []
+        for _ in range(6):
+            msg = queue.get(timeout=1)
+            levels.append(msg.payload["level"])
+
+        assert TRACE in levels
+        assert logging.DEBUG in levels
+        assert logging.INFO in levels
+        assert logging.WARNING in levels
+        assert logging.ERROR in levels
+        assert logging.CRITICAL in levels
+
+    def test_handler_non_blocking(self) -> None:
+        """Test handler doesn't block when queue is full."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue(maxsize=1)
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.blocking")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        # fill queue
+        logger.info("Message 1")
+
+        # this should not block (will drop silently)
+        logger.info("Message 2")
+
+        # should complete without hanging
+        assert queue.qsize() == 1
+
+    def test_handler_with_exception_doesnt_crash(self) -> None:
+        """Test handler gracefully handles exceptions."""
+        from unittest.mock import Mock
+
+        # create mock queue that raises exception
+        queue = Mock()
+        queue.put.side_effect = Exception("Queue error")
+
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.exception")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        # this should not raise exception (logging must not break app)
+        logger.info("This should not crash")
+
+        # verify we're still alive
+        assert True
+
+    def test_handler_with_args_formatting(self) -> None:
+        """Test handler formats messages with arguments."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.args")
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        logger.info("Value: %d, Name: %s", 42, "test")
+
+        msg = queue.get(timeout=1)
+        assert "Value: 42" in msg.payload["message"]
+        assert "Name: test" in msg.payload["message"]
+
+    def test_handler_respects_log_level(self) -> None:
+        """Test handler respects logger level."""
+        queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = QueueLoggingHandler(queue, "test")
+
+        logger = logging.getLogger("test.level")
+        logger.addHandler(handler)
+        logger.setLevel(logging.WARNING)  # only WARNING and above
+
+        logger.debug("Should not appear")
+        logger.info("Should not appear")
+        logger.warning("Should appear")
+
+        # only one message should be in queue
+        msg = queue.get(timeout=1)
+        assert "Should appear" in msg.payload["message"]
+
+        # queue should be empty
+        assert queue.empty()

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -9,13 +9,11 @@ Tests for logging setup.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 import pytest
 
-from cpu.config.config import Config
 from cpu.logging.queue_handler import QueueLoggingHandler
-from cpu.logging.setup import TRACE, configure_logging, configure_queue_logging
+from cpu.logging.setup import TRACE, configure_queue_logging
 from cpu.messaging.message import Message, MessageType
 from cpu.messaging.queue_thread import ThreadMessageQueue
 
@@ -76,116 +74,6 @@ class TestTraceLevel:
         assert len(caplog.records) == 2
         assert caplog.records[0].levelname == "TRACE"
         assert caplog.records[1].levelname == "DEBUG"
-
-
-class TestLoggingSetup:
-    """Test logging configuration."""
-
-    def test_configure_logging_creates_file_handler(self, tmp_path: Path) -> None:
-        """Test file handler is created."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: INFO
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        configure_logging(config)
-
-        root_logger = logging.getLogger()
-        # should have file handler
-        assert any(isinstance(handler, logging.FileHandler) for handler in root_logger.handlers)
-
-    def test_configure_logging_sets_levels(self, tmp_path: Path) -> None:
-        """Test logging level is set."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: DEBUG
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        configure_logging(config)
-
-        root_logger = logging.getLogger()
-        assert root_logger.level == logging.DEBUG
-
-    def test_configure_logging_hierarchical_loggers(self, tmp_path: Path) -> None:
-        """Test hierarchical logger levels."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: WARNING
-    loggers:
-      cpu.timer: DEBUG
-      cpu.job_manager: INFO
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        configure_logging(config)
-
-        timer_logger = logging.getLogger("cpu.timer")
-        job_logger = logging.getLogger("cpu.job_manager")
-
-        assert timer_logger.level == logging.DEBUG
-        assert job_logger.level == logging.INFO
-
-    def test_configure_logging_uses_format_from_config(self, tmp_path: Path) -> None:
-        """Test custom log format is applied."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: INFO
-    format: "%(levelname)s - %(message)s"
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        # clear existing handlers (pytest adds its own)
-        root_logger = logging.getLogger()
-        root_logger.handlers.clear()
-
-        configure_logging(config)
-
-        file_handlers = [handler for handler in root_logger.handlers if isinstance(handler, logging.FileHandler)]
-        assert len(file_handlers) > 0
-
-        formatter = file_handlers[0].formatter
-        assert formatter is not None
-        assert formatter._fmt == "%(levelname)s - %(message)s"
-
-    def test_configure_logging_with_trace_level(self, tmp_path: Path) -> None:
-        """Test TRACE level can be configured."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("""
-bot:
-  logging:
-    file: logs/cpu.log
-    level: TRACE
-""")
-
-        config = Config(config_file=config_file)
-        config.load()
-
-        configure_logging(config)
-
-        root_logger = logging.getLogger()
-        assert root_logger.level == TRACE
 
 
 class TestConfigureQueueLogging:

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -14,7 +14,10 @@ from pathlib import Path
 import pytest
 
 from cpu.config.config import Config
-from cpu.logging.setup import TRACE, configure_logging
+from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.logging.setup import TRACE, configure_logging, configure_queue_logging
+from cpu.messaging.message import Message, MessageType
+from cpu.messaging.queue_thread import ThreadMessageQueue
 
 
 class TestTraceLevel:
@@ -183,3 +186,92 @@ bot:
 
         root_logger = logging.getLogger()
         assert root_logger.level == TRACE
+
+
+class TestConfigureQueueLogging:
+    """Test queue-based logging configuration."""
+
+    def test_cpu_logger_gets_queue_handler(self) -> None:
+        """Test the cpu logger is configured with a QueueLoggingHandler."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue)
+
+        cpu_logger = logging.getLogger("cpu")
+        assert len(cpu_logger.handlers) == 1
+        assert isinstance(cpu_logger.handlers[0], QueueLoggingHandler)
+
+    def test_log_message_lands_in_queue(self) -> None:
+        """Test a log call on a cpu.* logger ends up in the queue."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue)
+
+        logger = logging.getLogger("cpu.some.module")
+        logger.info("Hello queue")
+
+        msg = log_queue.get(timeout=1)
+        assert msg.type == MessageType.LOG
+        assert "Hello queue" in msg.payload["message"]
+        assert msg.payload["name"] == "cpu.some.module"
+
+    def test_existing_handlers_replaced(self) -> None:
+        """Test previously configured handlers are removed."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        cpu_logger = logging.getLogger("cpu")
+        cpu_logger.addHandler(logging.NullHandler())
+        cpu_logger.addHandler(logging.NullHandler())
+
+        configure_queue_logging(log_queue)
+
+        assert len(cpu_logger.handlers) == 1
+        assert isinstance(cpu_logger.handlers[0], QueueLoggingHandler)
+
+    def test_no_propagation_to_root(self) -> None:
+        """Test cpu logger does not propagate to root logger."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue)
+
+        cpu_logger = logging.getLogger("cpu")
+        assert cpu_logger.propagate is False
+
+    def test_level_respected(self) -> None:
+        """Test messages below the configured level are not queued."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue, level=logging.WARNING)
+
+        logger = logging.getLogger("cpu.some.module")
+        logger.info("Filtered out")
+        logger.warning("Passes through")
+
+        msg = log_queue.get(timeout=1)
+        assert "Passes through" in msg.payload["message"]
+        assert log_queue.empty()
+
+    def test_trace_level_supported(self) -> None:
+        """Test TRACE level messages flow through when configured."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue, level=TRACE)
+
+        logger = logging.getLogger("cpu.some.module")
+        logger.log(TRACE, "Trace through queue")
+
+        msg = log_queue.get(timeout=1)
+        assert msg.payload["level"] == TRACE
+        assert "Trace through queue" in msg.payload["message"]
+
+    def test_source_component_set(self) -> None:
+        """Test the source component name is attached to messages."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        configure_queue_logging(log_queue, source_component="event_handler")
+
+        logger = logging.getLogger("cpu.some.module")
+        logger.info("Tagged message")
+
+        msg = log_queue.get(timeout=1)
+        assert msg.source == "event_handler"


### PR DESCRIPTION
## [0.0.9] - 2026-06-13

### Added

- `QueueLoggingHandler`: custom logging handler that routes all `cpu.*`
  log records through the message queue to `LoggingComponent`, enabling
  async, non-blocking logging
- `suppress_queue_logging()`: thread-local context manager to prevent
  feedback loops when `LoggingComponent` drains its own queue
- `configure_queue_logging()`: configures the `cpu` logger to use
  `QueueLoggingHandler`, replacing direct file writes
- Integration tests for the full logging chain (handler → queue →
  `LoggingComponent` → file)
- `logging_component` pytest fixture in `conftest.py`

### Changed

- `LoggingComponent` is now the sole writer to the log file; all
  `cpu.*` logging flows through the message queue
- `LoggingComponent` uses `CompressingRotatingFileHandler` instead of
  plain `FileHandler`, restoring log rotation with gzip compression
- `LoggingComponent` preserves original log record metadata (logger
  name, function name, line number) in file output
- `__main__.py` uses two-phase logging: console-only during startup,
  queue-based once `LoggingComponent` is registered
- `Orchestrator.stop_all()` stops components in reverse registration
  order, ensuring `LoggingComponent` stops last
- Default banner effect changed from `Slide` to `Beams`
- Console startup logging reduced to `WARNING` level

### Fixed

- `LoggingComponent` config keys aligned with sub-dict passed from
  `__main__.py` (removed erroneous `bot.logging.` prefix)
- Infinite feedback loop at TRACE level when `LoggingComponent`'s own
  queue operations generated log records
- Propagation disabled on `cpu.logging` logger to prevent write →
  propagate → queue loop

### Removed

- `configure_logging()` from `setup.py` — replaced by
  `configure_queue_logging()`