### PR TITLE
Release v0.0.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Upload source and wheel
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0    a # v7.0.1
       with:
         name: dist-package
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Upload source and wheel
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0    a # v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dist-package
         path: |

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -65,7 +65,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
@@ -73,6 +73,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@9fdb3e49720b44c48891d036bb502feb25684276 # v3.25.6
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Upload coverage artifact
       if: always()
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0    a # v7.0.1
       with:
         name: coverage-report-${{ matrix.os }}-py${{ matrix.python-version }}
         path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Upload coverage artifact
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
         name: coverage-report-${{ matrix.os }}-py${{ matrix.python-version }}
         path: |
@@ -51,7 +51,7 @@ jobs:
           htmlcov/
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage.xml
         flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Upload coverage artifact
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0    a # v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage-report-${{ matrix.os }}-py${{ matrix.python-version }}
         path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.0.10] - 2026-06-16
+
+### Added
+
+- `SmeeClientComponent`: new component with unit tests (#61)
+- Python 3.13 and 3.14 to the test matrix (#60)
+
+### Changed
+
+- `SmeeClientComponent` is now used in `__main__.py`, with integration
+  tests added/fixed (#63)
+- pinned CI versions updated; GitHub Action warnings about deprecated
+  Node versions fixed (#60)
+- pytest coverage increased to 100% (#60)
+- `terminaltexteffects` bumped to v0.15.0 (#60)
+
+### Fixed
+
+- location of `secrets_audit.log` made configurable, fixing fragile
+  `/var/log/cpu` default for non-root deployments (#62, via #63)
+
+### Removed
+
+- unused `create_webhook_message()` and associated tests (#61)
+
 ## [0.0.9] - 2026-06-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "APScheduler>=3.10.0",        # Periodic task scheduling (timer component)
     "cryptography>=41.0.0",       # Encryption for secret storage and webhook signature validation
     "typing-extensions>=4.5.0; python_version < '3.10'",  # Backport modern type hints for Python 3.9
-    "terminaltexteffects==0.12.0",  # TerminalTextEffects (version 0.13.0 failed to install)
+    "terminaltexteffects==0.15.0",  # TerminalTextEffects (version 0.13.0 failed to install)
 ]
 
 [project.optional-dependencies]

--- a/src/cpu/__main__.py
+++ b/src/cpu/__main__.py
@@ -18,10 +18,13 @@ from typing import NoReturn
 from cpu import __version__
 from cpu.components.orchestrator import Orchestrator
 from cpu.config.config import Config, ConfigError, ConfigValidationError
+from cpu.config.secrets import SecretManager
 from cpu.logging.component import LoggingComponent
 from cpu.logging.setup import TRACE, configure_queue_logging
+from cpu.messaging.bus_thread import ThreadMessageBus
 from cpu.messaging.message import Message
 from cpu.messaging.queue_thread import ThreadMessageQueue
+from cpu.smee.client import SmeeClientComponent
 
 logger = logging.getLogger(__name__)
 
@@ -64,10 +67,25 @@ def create_orchestrator(config: Config) -> Orchestrator:
         level=log_level,
     )
 
+    # shared message bus for inter-component pub/sub (e.g. webhook_events)
+    message_bus: ThreadMessageBus[Message] = ThreadMessageBus()
+
+    # Smee client (optional, dev-only): forwards webhook events from a
+    # smee.io channel onto the "webhook_events" topic
+    if config.get("secrets.smee"):
+        secrets_manager = SecretManager(config)
+        smee_client = SmeeClientComponent(
+            name="smee",
+            message_bus=message_bus,
+            secrets_manager=secrets_manager,
+        )
+        orchestrator.register(smee_client)
+    else:
+        logger.info("No Smee configuration found; SmeeClientComponent not registered")
+
     # TODO register components as they're implemented
     # orchestrator.register(EventHandlerComponent(...))
     # orchestrator.register(JobManagerComponent(...))
-    # orchestrator.register(SmeeClientComponent(...))
     # orchestrator.register(TimerComponent(...))
     # orchestrator.register(WorkerPoolComponent(...))
 

--- a/src/cpu/config/secrets.py
+++ b/src/cpu/config/secrets.py
@@ -373,7 +373,7 @@ class SecretManager:
 
         # Initialize audit logger
         if audit_logger is None:
-            audit_logger = SecretsAuditLogger()
+            audit_logger = self._create_audit_logger()
         self.audit = audit_logger
 
         # Initialize sources
@@ -388,6 +388,21 @@ class SecretManager:
         self._smee_cache: dict[str, SmeeSecrets] = {}
 
         logger.info(f"Initialized SecretManager with {len(self.sources)} sources")
+
+    def _create_audit_logger(self) -> SecretsAuditLogger:
+        """
+        Create the secrets audit logger from configuration.
+
+        Reads ``secrets.audit_log_file`` (defaults to ``logs/secrets_audit.log``,
+        relative to the current working directory) to avoid the historical
+        ``/var/log/cpu/secrets_audit.log`` default, which typically requires
+        root privileges and is not writable in most deployments.
+
+        Returns:
+            Configured SecretsAuditLogger
+        """
+        audit_log_file = self.config.get("secrets.audit_log_file", "logs/secrets_audit.log")
+        return SecretsAuditLogger(audit_file=Path(audit_log_file))
 
     def _create_encryption_provider(self) -> EncryptionProvider:
         """Create encryption provider from configuration."""

--- a/src/cpu/config/secrets_audit.py
+++ b/src/cpu/config/secrets_audit.py
@@ -29,7 +29,7 @@ class SecretsAuditLogger:
 
     def __init__(
         self,
-        audit_file: Path = Path("/var/log/cpu/secrets_audit.log"),
+        audit_file: Path = Path("logs/secrets_audit.log"),
         enable_console: bool = False,
     ) -> None:
         """

--- a/src/cpu/messaging/delivery.py
+++ b/src/cpu/messaging/delivery.py
@@ -184,7 +184,7 @@ class AtLeastOnceDelivery(MessageDeliveryInterface[T], Generic[T]):
         start_time = time.time()
         attempts = 0
 
-        while attempts <= self.max_retries:
+        while attempts <= self.max_retries:  # pragma: no branch
             # Check total timeout
             if timeout is not None:
                 elapsed = time.time() - start_time
@@ -341,7 +341,7 @@ class ExactlyOnceDelivery(MessageDeliveryInterface[T], Generic[T]):
         start_time = time.time()
         attempts = 0
 
-        while attempts <= self.max_retries:
+        while attempts <= self.max_retries:  # pragma: no branch
             if timeout is not None:
                 elapsed = time.time() - start_time
                 if elapsed >= timeout:

--- a/src/cpu/messaging/delivery.py
+++ b/src/cpu/messaging/delivery.py
@@ -217,6 +217,8 @@ class AtLeastOnceDelivery(MessageDeliveryInterface[T], Generic[T]):
                 else:
                     time.sleep(self.retry_delay)
 
+        return False  # pragma: no cover
+
     def receive(
         self, queue: MessageQueueInterface[T], timeout: float | None = None
     ) -> T | None:
@@ -374,6 +376,8 @@ class ExactlyOnceDelivery(MessageDeliveryInterface[T], Generic[T]):
                     time.sleep(sleep_time)
                 else:
                     time.sleep(self.retry_delay)
+
+        return False  # pragma: no cover
 
     def receive(
         self, queue: MessageQueueInterface[T], timeout: float | None = None

--- a/src/cpu/messaging/delivery.py
+++ b/src/cpu/messaging/delivery.py
@@ -152,6 +152,8 @@ class AtLeastOnceDelivery(MessageDeliveryInterface[T], Generic[T]):
             max_retries: Maximum retry attempts (default: 3)
             retry_delay: Delay between retries in seconds (default: 1.0)
         """
+        if max_retries < 0:
+            raise ValueError(f"max_retries must be >= 0, got {max_retries}")
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self._pending: set[str] = set()  # Track unacknowledged message IDs
@@ -214,8 +216,6 @@ class AtLeastOnceDelivery(MessageDeliveryInterface[T], Generic[T]):
                     time.sleep(sleep_time)
                 else:
                     time.sleep(self.retry_delay)
-
-        return False
 
     def receive(
         self, queue: MessageQueueInterface[T], timeout: float | None = None
@@ -300,6 +300,8 @@ class ExactlyOnceDelivery(MessageDeliveryInterface[T], Generic[T]):
             retry_delay: Delay between retries in seconds (default: 1.0)
             max_processed_ids: Max processed IDs to track before cleanup (default: 10000)
         """
+        if max_retries < 0:
+            raise ValueError(f"max_retries must be >= 0, got {max_retries}")
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self.max_processed_ids = max_processed_ids
@@ -372,8 +374,6 @@ class ExactlyOnceDelivery(MessageDeliveryInterface[T], Generic[T]):
                     time.sleep(sleep_time)
                 else:
                     time.sleep(self.retry_delay)
-
-        return False
 
     def receive(
         self, queue: MessageQueueInterface[T], timeout: float | None = None

--- a/src/cpu/messaging/message.py
+++ b/src/cpu/messaging/message.py
@@ -148,30 +148,8 @@ class Message:
 
 
 # Type aliases for common message payloads
-WebhookPayload = dict[str, Any]
 JobPayload = dict[str, Any]
 TaskPayload = dict[str, Any]
-
-
-def create_webhook_message(
-    webhook_data: WebhookPayload, platform: str = "github"
-) -> Message:
-    """
-    Create a webhook message.
-
-    Args:
-        webhook_data: Raw webhook data from platform
-        platform: Platform name (github, gitlab, etc.)
-
-    Returns:
-        Message containing webhook data
-    """
-    logger.info(f"Creating webhook message from platform: {platform}")
-    return Message(
-        type=MessageType.WEBHOOK,
-        payload={"platform": platform, "data": webhook_data},
-        source="SmeeClient",
-    )
 
 
 def create_job_notification(

--- a/src/cpu/smee/client.py
+++ b/src/cpu/smee/client.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Smee webhook proxy client component.
+
+Connects to a smee.io (or compatible) channel via Server-Sent Events (SSE)
+and publishes incoming webhook events to a message bus topic, so any
+number of subscribers (typically the event handler) can receive them.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import queue
+import threading
+from typing import Any
+
+import requests
+
+from cpu.components.base import ComponentState, HealthStatus, RunnableComponent
+from cpu.config.secrets import SecretManager, SecretNotFoundError
+from cpu.messaging.interfaces import MessageBusInterface
+from cpu.messaging.message import Message, MessageType
+
+logger = logging.getLogger(__name__)
+
+
+class SmeeConnectionError(Exception):
+    """Raised when the Smee client cannot be configured or connected."""
+
+    pass
+
+
+class SmeeClientComponent(RunnableComponent):
+    """
+    Connects to a Smee channel and publishes received webhook events.
+
+    The component runs an SSE (Server-Sent Events) connection to the
+    configured Smee channel URL in a background thread. Incoming events
+    are parsed (JSON-decoded SSE ``data:`` lines) and placed on an
+    internal queue. The main component loop (``process_iteration``)
+    drains this queue and publishes each event as-is — as the
+    ``payload`` of a ``Message(type=MessageType.WEBHOOK, source=self.name)``
+    — to the configured topic on the message bus (pub/sub), so any
+    number of subscribers can receive a copy.
+
+    The payload is the raw JSON object received from Smee, typically
+    containing a ``body`` (the original webhook payload), ``query``
+    (forwarded query parameters), and the original request headers as
+    top-level keys (e.g. ``x-github-event``, ``x-github-delivery``).
+    This component does not inspect or interpret the payload contents
+    or determine the source platform (GitHub, GitLab, ...) — that is
+    left to downstream subscribers (e.g. the event handler).
+
+    Delivery is at-most-once: events are not persisted or retried by
+    this component if a subscriber fails to process them.
+
+    Reconnects automatically (with a configurable delay) if the SSE
+    connection fails or is closed by the server.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        message_bus: MessageBusInterface[Message],
+        secrets_manager: SecretManager,
+        topic: str = "webhook_events",
+        reconnect_delay: float = 5.0,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Create the Smee client component.
+
+        Args:
+            name: Component name
+            message_bus: Bus to publish received webhook events to
+            secrets_manager: Provides the Smee channel URL (treated as a
+                secret, since it grants access to the webhook channel)
+            topic: Topic to publish webhook messages to (pub/sub)
+            reconnect_delay: Seconds to wait before reconnecting after
+                a connection error
+            config: Optional configuration dictionary
+        """
+        super().__init__(name, config)
+        self.message_bus = message_bus
+        self.secrets_manager = secrets_manager
+        self.channel_url: str | None = None
+        self.topic = topic
+        self.reconnect_delay = reconnect_delay
+
+        self._event_queue: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._reader_thread: threading.Thread | None = None
+        self._reader_stop = threading.Event()
+        self._response: requests.Response | None = None
+
+    def initialize(self) -> None:
+        """
+        Resolve the Smee channel URL from secrets and prepare internal state.
+
+        Raises:
+            SmeeConnectionError: If the channel URL cannot be resolved
+        """
+        try:
+            secrets = self.secrets_manager.get_smee_secrets()
+        except SecretNotFoundError as err:
+            raise SmeeConnectionError(f"Failed to load Smee secrets: {err}") from err
+
+        if not secrets.channel_url:
+            raise SmeeConnectionError("Smee channel_url must be set")
+
+        self.channel_url = secrets.channel_url
+        self.state = ComponentState.INITIALIZED
+        logger.info(f"Initialized {self.name} for configured Smee channel")
+
+    def start(self) -> None:
+        """Start the SSE reader thread, then run the main processing loop."""
+        if self.state != ComponentState.INITIALIZED:
+            raise RuntimeError(f"Component {self.name} not initialized")
+
+        self._reader_stop.clear()
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop,
+            name=f"{self.name}-reader",
+            daemon=True,
+        )
+        self._reader_thread.start()
+
+        super().start()
+
+    def stop(self, timeout: float | None = None) -> None:
+        """
+        Stop the component and the SSE reader thread.
+
+        Args:
+            timeout: Maximum time to wait for the reader thread to stop
+        """
+        super().stop(timeout)
+
+        self._reader_stop.set()
+        if self._response is not None:
+            try:
+                self._response.close()
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                logger.debug(f"{self.name}: error closing SSE response", exc_info=True)
+
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=timeout)
+
+    def process_iteration(self) -> None:
+        """Drain the internal event queue and publish webhook messages."""
+        try:
+            event_data = self._event_queue.get(timeout=0.1)
+        except queue.Empty:
+            return
+
+        message = Message(
+            type=MessageType.WEBHOOK,
+            payload=event_data,
+            source=self.name,
+        )
+        self.message_bus.publish(self.topic, message)
+        logger.debug(f"{self.name}: published webhook message {message.id[:8]}... to '{self.topic}'")
+
+    def health_check(self) -> HealthStatus:
+        """
+        Check component health.
+
+        Returns:
+            HEALTHY if running and the SSE reader thread is alive,
+            UNHEALTHY otherwise.
+        """
+        if not self.is_running():
+            return HealthStatus.UNHEALTHY
+        if self._reader_thread is None or not self._reader_thread.is_alive():
+            return HealthStatus.UNHEALTHY
+        return HealthStatus.HEALTHY
+
+    def _reader_loop(self) -> None:
+        """Connect to the Smee channel and feed parsed events into the queue."""
+        assert self.channel_url is not None  # set during initialize()
+        headers = {"Accept": "text/event-stream"}
+
+        while not self._reader_stop.is_set():
+            try:
+                logger.info(f"{self.name}: connecting to {self.channel_url}")
+                response = requests.get(
+                    self.channel_url,
+                    headers=headers,
+                    stream=True,
+                    timeout=(10, None),
+                )
+                response.raise_for_status()
+                self._response = response
+
+                for raw_line in response.iter_lines():
+                    if self._reader_stop.is_set():
+                        break
+
+                    event_data = self._parse_sse_line(raw_line)
+                    if event_data is not None:
+                        self._event_queue.put(event_data)
+
+            except Exception as err:  # noqa: BLE001 - any connection error triggers reconnect
+                logger.warning(f"{self.name}: connection error: {err}")
+            finally:
+                if self._response is not None:
+                    with contextlib.suppress(Exception):
+                        self._response.close()
+                    self._response = None
+
+            if not self._reader_stop.is_set():
+                self._reader_stop.wait(self.reconnect_delay)
+
+        logger.info(f"{self.name}: reader thread stopped")
+
+    @staticmethod
+    def _parse_sse_line(raw_line: bytes | str) -> dict[str, Any] | None:
+        """
+        Parse a single SSE line, returning event data if it's a usable
+        'data:' line containing JSON, or None otherwise.
+
+        Args:
+            raw_line: A line yielded by requests' iter_lines()
+
+        Returns:
+            Parsed JSON payload as dict, or None if the line should be skipped
+        """
+        if isinstance(raw_line, bytes):
+            line = raw_line.decode("utf-8", errors="replace")
+        else:
+            line = raw_line
+
+        if not line.startswith("data:"):
+            return None
+
+        data = line[len("data:"):].strip()
+        if not data:
+            return None
+
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError:
+            logger.debug("Ignoring non-JSON SSE data line")
+            return None
+
+        if not isinstance(parsed, dict):
+            logger.debug("Ignoring non-object SSE JSON payload")
+            return None
+
+        return parsed

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -4,12 +4,15 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from pathlib import Path
 
 from cpu.__main__ import create_orchestrator
 from cpu.config.config import Config
 from cpu.logging.queue_handler import QueueLoggingHandler
+from cpu.messaging.interfaces import QueueEmptyError
+from cpu.messaging.message import MessageType
 
 
 class TestMainLoggingWiring:
@@ -62,7 +65,11 @@ bot:
             h for h in cpu_logger.handlers if isinstance(h, QueueLoggingHandler)
         )
 
-        from cpu.messaging.message import MessageType
+        # Drain any messages queued during create_orchestrator() itself
+        # (e.g. component initialization logs).
+        with contextlib.suppress(QueueEmptyError):
+            while True:
+                handler._queue.get(block=False)
 
         cpu_logger.info("Post-orchestrator log")
 

--- a/tests/integration/test_main_orchestration.py
+++ b/tests/integration/test_main_orchestration.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cpu.__main__ import create_orchestrator, main, run_orchestrator
 from cpu.config.config import Config
+from cpu.config.secrets_audit import SecretsAuditLogger
 
 
 class TestCreateOrchestrator:
@@ -32,6 +35,38 @@ class TestCreateOrchestrator:
         # increase right-hand value with increasing number of components
         # TODO maybe this should be configurable and then compare against configured number
         assert len(orchestrator._components) == 1
+
+    def test_create_orchestrator_registers_smee_client_when_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test SmeeClientComponent is registered when secrets.smee is configured."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+bot:
+  num_workers: 2
+secrets:
+  smee:
+    - name: default
+      context: {}
+      refs:
+        channel_url: smee.channel_url
+""")
+        monkeypatch.setenv("CPU_SECRETS__SMEE__CHANNEL_URL", "https://smee.io/test-channel")
+
+        # Avoid SecretsAuditLogger's default /var/log/cpu, which may not be writable.
+        audit_file = tmp_path / "secrets_audit.log"
+        monkeypatch.setattr(
+            "cpu.config.secrets.SecretsAuditLogger",
+            lambda *args, **kwargs: SecretsAuditLogger(audit_file=audit_file),  # noqa: ARG005
+        )
+
+        config = Config(config_file=config_file)
+        config.load()
+
+        orchestrator = create_orchestrator(config)
+
+        assert "smee" in orchestrator._components
+        assert len(orchestrator._components) == 2
 
 
 class TestRunOrchestrator:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from cpu.__main__ import main
+from cpu.__main__ import main, print_banner
 
 
 class TestMainCLI:
@@ -405,6 +405,13 @@ bot:
         captured = capsys.readouterr()
         assert "CPU" in captured.out
 
+    def test_print_banner_without_config(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test print_banner with no config defaults to plain banner."""
+        print_banner("TEST BANNER")
+
+        captured = capsys.readouterr()
+        assert "TEST BANNER" in captured.out
+
 
 class TestExtendedStartupInfo:
     """Test extended startup info flag."""
@@ -600,7 +607,7 @@ bot:
 
         mock_terminal = MagicMock()
         mock_terminal.__enter__ = lambda self: self
-        mock_terminal.__exit__ = lambda: None
+        mock_terminal.__exit__ = lambda _self, _exc_type, _exc_val, _exc_tb: None
         mock_terminal.print = MagicMock()
 
         mock_effect_instance = MagicMock()

--- a/tests/unit/test_components_base.py
+++ b/tests/unit/test_components_base.py
@@ -171,6 +171,25 @@ class TestRunnableComponentClass:
 
         assert component.get_state() == ComponentState.FAILED
 
+    def test_finally_skips_stopped_when_state_already_failed(self) -> None:
+        """Test finally block doesn't overwrite FAILED state set during normal iteration."""
+        class SelfFailingComponent(RunnableComponent):
+            def initialize(self) -> None:
+                self.state = ComponentState.INITIALIZED
+
+            def process_iteration(self) -> None:
+                self.state = ComponentState.FAILED
+                self._stop_requested = True
+
+            def health_check(self) -> HealthStatus:
+                return HealthStatus.UNHEALTHY
+
+        component = SelfFailingComponent(name="test")
+        component.initialize()
+        component.start()
+
+        assert component.get_state() == ComponentState.FAILED
+
 
 class TestComponentBaseLogging:
     """Test logging added to base component classes."""

--- a/tests/unit/test_components_orchestrator.py
+++ b/tests/unit/test_components_orchestrator.py
@@ -351,6 +351,19 @@ class TestOrchestratorSignalHandling:
         assert comp is not None
         assert comp.get_state() == ComponentState.STOPPED
 
+    def test_signal_handler_sets_shutdown_and_stops_components(self) -> None:
+        """Test _signal_handler sets shutdown flag and stops components."""
+        import signal as signal_module
+        from unittest.mock import patch
+
+        orchestrator = Orchestrator()
+
+        with patch.object(orchestrator, "stop_all") as mock_stop_all:
+            orchestrator._signal_handler(signal_module.SIGTERM, None)
+
+        assert orchestrator._shutdown_requested is True
+        mock_stop_all.assert_called_once_with(timeout=10)
+
 
 class TestOrchestratorHealthMonitoring:
     """Test health monitoring in orchestrator."""

--- a/tests/unit/test_config_secrets.py
+++ b/tests/unit/test_config_secrets.py
@@ -1002,8 +1002,26 @@ secrets:
         with patch("cpu.config.secrets.SecretsAuditLogger") as mock_audit_cls:
             manager = SecretManager(config)
 
-        mock_audit_cls.assert_called_once_with()
+        mock_audit_cls.assert_called_once_with(audit_file=Path("logs/secrets_audit.log"))
         assert manager.audit is mock_audit_cls.return_value
+
+    def test_secret_manager_audit_logger_path_configurable(self, tmp_path: Path) -> None:
+        """Test secrets.audit_log_file overrides the default audit log path."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+bot:
+  num_workers: 1
+secrets:
+  audit_log_file: custom/audit.log
+""")
+
+        config = Config(config_file)
+        config.load()
+
+        with patch("cpu.config.secrets.SecretsAuditLogger") as mock_audit_cls:
+            SecretManager(config)
+
+        mock_audit_cls.assert_called_once_with(audit_file=Path("custom/audit.log"))
 
     def test_create_sources_with_file_source(self, tmp_path: Path) -> None:
         """Test _create_sources_from_config creates FileSecretSource for 'file' type."""

--- a/tests/unit/test_config_secrets.py
+++ b/tests/unit/test_config_secrets.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -549,6 +549,37 @@ secrets:
         with pytest.raises(SecretNotFoundError):
             manager.get_github_secrets(context)
 
+    def test_get_github_secrets_with_installation_id(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test get_github_secrets loads optional installation_id ref."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+secrets:
+  github:
+    - name: default
+      context: {}
+      refs:
+        app_id: github.default.app_id
+        private_key: github.default.private_key
+        webhook_secret: github.default.webhook_secret
+        installation_id: github.default.installation_id
+""")
+
+        config = Config(config_file)
+        config.load()
+
+        monkeypatch.setenv("CPU_SECRETS__GITHUB__DEFAULT__APP_ID", "12345")
+        monkeypatch.setenv("CPU_SECRETS__GITHUB__DEFAULT__PRIVATE_KEY", "fake-key")
+        monkeypatch.setenv("CPU_SECRETS__GITHUB__DEFAULT__WEBHOOK_SECRET", "secret")
+        monkeypatch.setenv("CPU_SECRETS__GITHUB__DEFAULT__INSTALLATION_ID", "67890")
+
+        audit_logger = SecretsAuditLogger(audit_file=tmp_path / "audit.log")
+        manager = SecretManager(config, audit_logger=audit_logger)
+
+        context = SecretContext(platform="github")
+        secrets = manager.get_github_secrets(context)
+
+        assert secrets.app_id == "12345"
+
     def test_secrets_cached_after_first_load(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -629,6 +660,30 @@ secrets:
         secrets2 = manager.get_gitlab_secrets(context)
         assert secrets2 is secrets
 
+    def test_get_gitlab_secrets_wraps_secret_not_found(self, tmp_path: Path) -> None:
+        """Test get_gitlab_secrets wraps SecretNotFoundError from missing refs."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+secrets:
+  gitlab:
+    - name: default
+      context: {}
+      refs:
+        token: gitlab.token
+        webhook_secret: gitlab.webhook
+""")
+
+        config = Config(config_file)
+        config.load()
+
+        audit_logger = SecretsAuditLogger(audit_file=tmp_path / "audit.log")
+        manager = SecretManager(config, audit_logger=audit_logger)
+
+        context = SecretContext(platform="gitlab")
+
+        with pytest.raises(SecretNotFoundError, match="Failed to load GitLab secrets for config 'default'"):
+            manager.get_gitlab_secrets(context)
+
     def test_get_s3_secrets(self, tmp_path: Path) -> None:
         """Test get_s3_secrets retrieves and caches secrets."""
         # Setup secrets
@@ -673,6 +728,30 @@ secrets:
         # Test cache hit
         secrets2 = manager.get_s3_secrets(context)
         assert secrets2 is secrets
+
+    def test_get_s3_secrets_wraps_secret_not_found(self, tmp_path: Path) -> None:
+        """Test get_s3_secrets wraps SecretNotFoundError from missing refs."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+secrets:
+  s3:
+    - name: default
+      context: {}
+      refs:
+        access_key_id: s3.access_key
+        secret_access_key: s3.secret_key
+""")
+
+        config = Config(config_file)
+        config.load()
+
+        audit_logger = SecretsAuditLogger(audit_file=tmp_path / "audit.log")
+        manager = SecretManager(config, audit_logger=audit_logger)
+
+        context = SecretContext(cvmfs_repo="software.eessi.io")
+
+        with pytest.raises(SecretNotFoundError, match="Failed to load S3 secrets for config 'default'"):
+            manager.get_s3_secrets(context)
 
     def test_get_s3_secrets_optional_fields(self, tmp_path: Path) -> None:
         """Test get_s3_secrets with only required fields."""
@@ -745,6 +824,26 @@ secrets:
         # Test cache hit
         secrets2 = manager.get_smee_secrets()
         assert secrets2 is secrets
+
+    def test_get_smee_secrets_wraps_secret_not_found(self, tmp_path: Path) -> None:
+        """Test get_smee_secrets wraps SecretNotFoundError from missing refs."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("""
+secrets:
+  smee:
+    - name: default
+      refs:
+        channel_url: smee.channel_url
+""")
+
+        config = Config(config_file)
+        config.load()
+
+        audit_logger = SecretsAuditLogger(audit_file=tmp_path / "audit.log")
+        manager = SecretManager(config, audit_logger=audit_logger)
+
+        with pytest.raises(SecretNotFoundError, match="Failed to load Smee secrets for config 'default'"):
+            manager.get_smee_secrets()
 
     def test_get_gitlab_secrets_no_matching_config(self, tmp_path: Path) -> None:
         """Test get_gitlab_secrets raises error when no config matches."""
@@ -891,6 +990,42 @@ secrets:
 
         assert len(manager.sources) == 1
         assert manager.sources[0] is custom_source
+
+    def test_secret_manager_creates_default_audit_logger(self, tmp_path: Path) -> None:
+        """Test SecretManager creates a default SecretsAuditLogger when none provided."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("bot:\n  num_workers: 1")
+
+        config = Config(config_file)
+        config.load()
+
+        with patch("cpu.config.secrets.SecretsAuditLogger") as mock_audit_cls:
+            manager = SecretManager(config)
+
+        mock_audit_cls.assert_called_once_with()
+        assert manager.audit is mock_audit_cls.return_value
+
+    def test_create_sources_with_file_source(self, tmp_path: Path) -> None:
+        """Test _create_sources_from_config creates FileSecretSource for 'file' type."""
+        secrets_dir = tmp_path / "secrets"
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(f"""
+bot:
+  num_workers: 1
+secrets:
+  sources:
+    - type: file
+      secrets_dir: {secrets_dir}
+    - type: vault
+""")
+
+        config = Config(config_file)
+        config.load()
+
+        audit_logger = SecretsAuditLogger(audit_file=tmp_path / "audit.log")
+        manager = SecretManager(config, audit_logger=audit_logger)
+
+        assert any(isinstance(s, FileSecretSource) for s in manager.sources)
 
 
 class TestSecretsLogging:

--- a/tests/unit/test_config_secrets_encryption.py
+++ b/tests/unit/test_config_secrets_encryption.py
@@ -169,6 +169,21 @@ class TestMasterPassphraseEncryption:
         assert encrypted != plaintext
         assert decrypted == plaintext
 
+    def test_decrypt_raises_on_unexpected_exception(self) -> None:
+        """Test decrypt wraps unexpected exceptions in DecryptionError."""
+        from unittest.mock import patch
+
+        from cryptography.fernet import Fernet
+
+        provider = MasterPassphraseEncryption(passphrase="test")
+        encrypted = provider.encrypt(b"plaintext")
+
+        with (
+            patch.object(Fernet, "decrypt", side_effect=ValueError("unexpected")),
+            pytest.raises(DecryptionError, match="Decryption failed")
+        ):
+            provider.decrypt(encrypted)
+
 
 class TestEncryptionConfig:
     """Test EncryptionConfig."""

--- a/tests/unit/test_logging_component.py
+++ b/tests/unit/test_logging_component.py
@@ -203,6 +203,14 @@ class TestLoggingComponent:
         # should not raise
         component.stop()
 
+    def test_flush_before_initialize_is_noop(self) -> None:
+        """Test flush() does nothing if called before initialize()."""
+        log_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        component = LoggingComponent(name="logger", log_queue=log_queue)
+
+        # should not raise even though _file_handler is None
+        component.flush()
+
     def test_logging_component_flush_handler_ignores_other_signals(self, tmp_path: Path) -> None:
         """Test flush handler ignores non-SIGUSR1 signals."""
         import signal

--- a/tests/unit/test_logging_rotation.py
+++ b/tests/unit/test_logging_rotation.py
@@ -358,3 +358,58 @@ class TestRotationLogging:
             with gzip.open(backup, 'rb') as file:
                 content = file.read()
                 assert len(content) == 0  # empty compressed file
+
+    def test_rollover_logs_error_removing_existing_destination(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test doRollover logs error when removing existing .1.gz before compression fails."""
+        caplog.set_level(logging.ERROR)
+
+        log_file = tmp_path / "test.log"
+        log_file.write_text("current log data")
+
+        existing_backup = tmp_path / "test.log.1.gz"
+        with gzip.open(existing_backup, "wb") as f:
+            f.write(b"old backup")
+
+        handler = CompressingRotatingFileHandler(
+            filename=str(log_file),
+            maxBytes=100,
+            backupCount=1,  # loop range(0,0,-1) is empty, so .1.gz is not renamed away
+        )
+
+        import os
+        real_remove = os.remove
+        call_count = 0
+
+        def fail_first_remove(path: str) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OSError("Permission denied")
+            real_remove(path)
+
+        with patch("os.remove", side_effect=fail_first_remove):
+            handler.doRollover()
+
+        assert "Failed to remove file during rotation" in caplog.text
+
+    def test_rollover_skips_compression_when_base_file_absent(self, tmp_path: Path) -> None:
+        """Test doRollover with delay=True and no base log file skips compression."""
+        log_file = tmp_path / "test.log"
+        # deliberately do NOT create the file
+
+        handler = CompressingRotatingFileHandler(
+            filename=str(log_file),
+            maxBytes=100,
+            backupCount=3,
+            delay=True,
+        )
+
+        # should not raise even though base file doesn't exist
+        handler.doRollover()
+
+        # no backup should be created since there was nothing to compress
+        assert not (tmp_path / "test.log.1.gz").exists()
+        # stream should remain None because delay=True
+        assert handler.stream is None

--- a/tests/unit/test_messaging_delivery.py
+++ b/tests/unit/test_messaging_delivery.py
@@ -224,6 +224,16 @@ class TestAtLeastOnceDelivery:
         # Should not raise
         delivery.acknowledge(msg_dict)
 
+    def test_negative_max_retries_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_retries must be >= 0"):
+            AtLeastOnceDelivery(max_retries=-1)
+
+    def test_receive_returns_none_on_empty_queue(self) -> None:
+        queue = Mock(spec=MessageQueueInterface)
+        queue.get.side_effect = QueueEmptyError("Empty")
+        delivery: AtLeastOnceDelivery[Message] = AtLeastOnceDelivery()
+        assert delivery.receive(queue) is None
+
 
 class TestExactlyOnceDelivery:
     """Test ExactlyOnceDelivery implementation."""
@@ -427,6 +437,23 @@ class TestExactlyOnceDelivery:
         result2 = delivery.send(queue, msg)
         assert result2 is True
         assert msg.id in delivery._sent_ids
+
+    def test_negative_max_retries_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_retries must be >= 0"):
+            ExactlyOnceDelivery(max_retries=-1)
+
+    def test_receive_returns_none_on_empty_queue(self) -> None:
+        queue = Mock(spec=MessageQueueInterface)
+        queue.get.side_effect = QueueEmptyError("Empty")
+        delivery: ExactlyOnceDelivery[Message] = ExactlyOnceDelivery()
+        assert delivery.receive(queue) is None
+
+    def test_send_success_message_without_id(self) -> None:
+        queue = Mock(spec=MessageQueueInterface)
+        delivery: ExactlyOnceDelivery[dict[str, Any]] = ExactlyOnceDelivery()
+        result = delivery.send(queue, {"data": "test"})
+        assert result is True
+        assert len(delivery._sent_ids) == 0
 
 
 class TestAtMostOnceDeliveryLogging:

--- a/tests/unit/test_messaging_delivery.py
+++ b/tests/unit/test_messaging_delivery.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -233,6 +233,19 @@ class TestAtLeastOnceDelivery:
         queue.get.side_effect = QueueEmptyError("Empty")
         delivery: AtLeastOnceDelivery[Message] = AtLeastOnceDelivery()
         assert delivery.receive(queue) is None
+
+    def test_send_returns_false_when_remaining_time_exhausted(self) -> None:
+        """Test return False when timeout expires between retry elapsed checks."""
+        queue = Mock(spec=MessageQueueInterface)
+        queue.put.side_effect = QueueFullError("Full")
+        delivery: AtLeastOnceDelivery[Message] = AtLeastOnceDelivery(max_retries=3, retry_delay=1.0)
+        msg = Message(type=MessageType.WEBHOOK, payload={})
+
+        with patch("cpu.messaging.delivery.time") as mock_time:
+            mock_time.time.side_effect = [0.0, 0.0, 1.0]
+            result = delivery.send(queue, msg, timeout=0.5)
+
+        assert result is False
 
 
 class TestExactlyOnceDelivery:
@@ -454,6 +467,19 @@ class TestExactlyOnceDelivery:
         result = delivery.send(queue, {"data": "test"})
         assert result is True
         assert len(delivery._sent_ids) == 0
+
+    def test_send_returns_false_when_remaining_time_exhausted(self) -> None:
+        """Test return False when timeout expires between retry elapsed checks."""
+        queue = Mock(spec=MessageQueueInterface)
+        queue.put.side_effect = QueueFullError("Full")
+        delivery: ExactlyOnceDelivery[Message] = ExactlyOnceDelivery(max_retries=3, retry_delay=1.0)
+        msg = Message(type=MessageType.WEBHOOK, payload={})
+
+        with patch("cpu.messaging.delivery.time") as mock_time:
+            mock_time.time.side_effect = [0.0, 0.0, 1.0]
+            result = delivery.send(queue, msg, timeout=0.5)
+
+        assert result is False
 
 
 class TestAtMostOnceDeliveryLogging:

--- a/tests/unit/test_messaging_message.py
+++ b/tests/unit/test_messaging_message.py
@@ -22,7 +22,6 @@ from cpu.messaging.message import (
     MessageType,
     create_job_notification,
     create_status_check_message,
-    create_webhook_message,
 )
 
 
@@ -311,43 +310,6 @@ class TestMessageMethods:
 class TestMessageFactoryFunctions:
     """Tests for message factory functions."""
 
-    def test_create_webhook_message_default_platform(self) -> None:
-        """Test webhook message creation with default platform."""
-        webhook_data = {"action": "opened", "number": 123}
-
-        msg = create_webhook_message(webhook_data)
-
-        assert msg.type == MessageType.WEBHOOK
-        assert msg.payload["platform"] == "github"
-        assert msg.payload["data"] == webhook_data
-        assert msg.source == "SmeeClient"
-
-    def test_create_webhook_message_custom_platform(self) -> None:
-        """Test webhook message creation with custom platform."""
-        webhook_data = {"action": "merge"}
-
-        msg = create_webhook_message(webhook_data, platform="gitlab")
-
-        assert msg.type == MessageType.WEBHOOK
-        assert msg.payload["platform"] == "gitlab"
-        assert msg.payload["data"] == webhook_data
-        assert msg.source == "SmeeClient"
-
-    def test_create_webhook_message_complex_data(self) -> None:
-        """Test webhook message with complex webhook data."""
-        webhook_data = {
-            "action": "opened",
-            "pull_request": {
-                "number": 123,
-                "title": "Test PR",
-                "user": {"login": "testuser"}
-            }
-        }
-
-        msg = create_webhook_message(webhook_data)
-
-        assert msg.payload["data"]["pull_request"]["number"] == 123
-
     def test_create_job_notification_minimal(self) -> None:
         """Test job notification with minimal arguments."""
         msg = create_job_notification(job_id="slurm_123")
@@ -382,20 +344,17 @@ class TestMessageFactoryFunctions:
 
     def test_factory_functions_create_valid_messages(self) -> None:
         """Test all factory functions create valid Message objects."""
-        webhook = create_webhook_message({"test": 1})
         job = create_job_notification("job_1")
         status = create_status_check_message()
 
         # All should be Message instances
-        assert isinstance(webhook, Message)
         assert isinstance(job, Message)
         assert isinstance(status, Message)
 
         # All should have unique IDs
-        assert webhook.id != job.id != status.id
+        assert job.id != status.id
 
         # All should have timestamps
-        assert webhook.timestamp > 0
         assert job.timestamp > 0
         assert status.timestamp > 0
 
@@ -548,15 +507,6 @@ class TestMessageLogging:
 
         assert "Deserializing message" in caplog.text
         assert "test-id-" in caplog.text
-
-    def test_factory_webhook_logs_at_info(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Test webhook factory logs at INFO level."""
-        caplog.set_level(logging.INFO)
-
-        create_webhook_message({"test": 1}, platform="github")
-
-        assert "Creating webhook message" in caplog.text
-        assert "github" in caplog.text
 
     def test_factory_job_notification_logs_at_info(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test job notification factory logs at INFO level."""

--- a/tests/unit/test_smee_client.py
+++ b/tests/unit/test_smee_client.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Tests for cpu.smee.client module which provides the SmeeClientComponent.
+
+SmeeClientComponent connects to a smee.io (or compatible) channel via
+Server-Sent Events (SSE), and publishes incoming webhook events to a
+message bus topic so any number of subscribers (e.g. the event handler)
+can receive them.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cpu.components.base import ComponentState, HealthStatus
+from cpu.config.secrets import SecretManager, SecretNotFoundError, SmeeSecrets
+from cpu.messaging.bus_thread import ThreadMessageBus
+from cpu.messaging.message import Message, MessageType
+from cpu.smee.client import SmeeClientComponent, SmeeConnectionError
+
+
+def _make_secrets_manager(channel_url: str | None = "https://smee.io/abc123") -> MagicMock:
+    """Build a mocked SecretManager returning the given channel_url (or raising)."""
+    manager = MagicMock(spec=SecretManager)
+    if channel_url is None:
+        manager.get_smee_secrets.side_effect = SecretNotFoundError("no smee config")
+    else:
+        manager.get_smee_secrets.return_value = SmeeSecrets(channel_url=channel_url)
+    return manager
+
+
+def _sse_lines(*payloads: dict[str, Any]) -> list[bytes]:
+    """Build raw SSE 'data:' lines (as iter_lines would yield) for given payloads."""
+    lines: list[bytes] = []
+    for payload in payloads:
+        lines.append(f"data: {json.dumps(payload)}".encode())
+        lines.append(b"")  # blank line terminates an SSE event
+    return lines
+
+
+class FakeResponse:
+    """Minimal stand-in for requests.Response supporting streaming iteration."""
+
+    def __init__(self, lines: list[bytes], status_code: int = 200) -> None:
+        self._lines = lines
+        self.status_code = status_code
+        self.closed = False
+
+    def iter_lines(self) -> Iterator[bytes]:
+        for line in self._lines:
+            if self.closed:
+                return
+            yield line
+        # Simulate a long-lived connection that doesn't end on its own
+        # unless explicitly closed.
+        while not self.closed:
+            time.sleep(0.01)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class TestSmeeClientComponentInitialization:
+    """Tests for initialization and configuration."""
+
+    def test_initialization_sets_state(self) -> None:
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+        assert client.get_state() == ComponentState.INITIALIZED
+
+    def test_rejects_empty_channel_url(self) -> None:
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(channel_url=""),
+        )
+        with pytest.raises(SmeeConnectionError):
+            client.initialize()
+
+    def test_rejects_missing_secret(self) -> None:
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(channel_url=None),
+        )
+        with pytest.raises(SmeeConnectionError):
+            client.initialize()
+
+    def test_default_topic_is_webhook_events(self) -> None:
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        assert client.topic == "webhook_events"
+
+    def test_custom_topic(self) -> None:
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+            topic="custom_topic",
+        )
+        assert client.topic == "custom_topic"
+
+
+class TestSmeeClientComponentEventHandling:
+    """Tests for receiving and publishing webhook events."""
+
+    @patch("cpu.smee.client.requests.get")
+    def test_publishes_webhook_message_on_event(self, mock_get: MagicMock) -> None:
+        payload = {
+            "body": {"action": "opened", "number": 42},
+            "query": {},
+            "x-github-event": "pull_request",
+            "x-github-delivery": "abc-123",
+        }
+        mock_get.return_value = FakeResponse(_sse_lines(payload))
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        subscriber = bus.subscribe("webhook_events")
+
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+
+        msg = subscriber.get(timeout=2)
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert msg.type == MessageType.WEBHOOK
+        assert msg.payload == payload
+        assert msg.source == "smee"
+
+    @patch("cpu.smee.client.requests.get")
+    def test_ignores_non_data_lines(self, mock_get: MagicMock) -> None:
+        payload = {"body": {"ok": True}}
+        lines = [b": this is a comment", b"event: ready", b""] + _sse_lines(payload)
+        mock_get.return_value = FakeResponse(lines)
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        subscriber = bus.subscribe("webhook_events")
+
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+
+        msg = subscriber.get(timeout=2)
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert msg.payload == payload
+
+    @patch("cpu.smee.client.requests.get")
+    def test_ignores_malformed_json(self, mock_get: MagicMock) -> None:
+        good_payload = {"body": {"ok": True}}
+        lines = [b"data: not-json", b""] + _sse_lines(good_payload)
+        mock_get.return_value = FakeResponse(lines)
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        subscriber = bus.subscribe("webhook_events")
+
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+
+        msg = subscriber.get(timeout=2)
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert msg.payload == good_payload
+
+    @patch("cpu.smee.client.requests.get")
+    def test_no_subscribers_does_not_block(self, mock_get: MagicMock) -> None:
+        """Publishing with no subscribers should drop the message, not block."""
+        payload = {"body": {"ok": True}}
+        mock_get.return_value = FakeResponse(_sse_lines(payload))
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+        time.sleep(0.2)
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert client.get_state() == ComponentState.STOPPED
+
+    @patch("cpu.smee.client.requests.get")
+    def test_stop_during_line_iteration_breaks_loop(self, mock_get: MagicMock) -> None:
+        """If _reader_stop is set while iterating SSE lines, the loop should break early."""
+        first_payload = {"body": {"first": True}}
+        second_payload = {"body": {"second": True}}
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        subscriber = bus.subscribe("webhook_events")
+
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        # Custom response whose iter_lines sets _reader_stop after the first
+        # event, then yields a second event that should NOT be processed.
+        lines = _sse_lines(first_payload) + _sse_lines(second_payload)
+
+        class StoppingResponse(FakeResponse):
+            def iter_lines(self) -> Iterator[bytes]:
+                for i, line in enumerate(self._lines):
+                    if i == 2:  # after first event's data+blank lines
+                        client._reader_stop.set()
+                    yield line
+
+        mock_get.return_value = StoppingResponse(lines)
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+
+        msg = subscriber.get(timeout=2)
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert msg.payload == first_payload
+        # second event must not have been queued/published
+        assert subscriber.empty()
+        assert not thread.is_alive()
+
+
+class TestParseSseLine:
+    """Direct tests for SmeeClientComponent._parse_sse_line."""
+
+    def test_parses_bytes_data_line(self) -> None:
+        line = b'data: {"body": {"ok": true}}'
+        assert SmeeClientComponent._parse_sse_line(line) == {"body": {"ok": True}}
+
+    def test_parses_str_data_line(self) -> None:
+        line = 'data: {"body": {"ok": true}}'
+        assert SmeeClientComponent._parse_sse_line(line) == {"body": {"ok": True}}
+
+    def test_non_data_line_returns_none(self) -> None:
+        assert SmeeClientComponent._parse_sse_line(b"event: ready") is None
+
+    def test_empty_data_returns_none(self) -> None:
+        assert SmeeClientComponent._parse_sse_line(b"data:") is None
+        assert SmeeClientComponent._parse_sse_line(b"data:   ") is None
+
+    def test_non_json_data_returns_none(self) -> None:
+        assert SmeeClientComponent._parse_sse_line(b"data: not-json") is None
+
+    def test_non_object_json_returns_none(self) -> None:
+        assert SmeeClientComponent._parse_sse_line(b"data: [1, 2, 3]") is None
+        assert SmeeClientComponent._parse_sse_line(b"data: 42") is None
+
+
+class TestSmeeClientComponentLifecycle:
+    """Tests for start/stop lifecycle and reconnection."""
+
+    @patch("cpu.smee.client.requests.get")
+    def test_stop_terminates_cleanly(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = FakeResponse(_sse_lines({"body": {}}))
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+        time.sleep(0.2)
+
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert client.get_state() == ComponentState.STOPPED
+        assert not thread.is_alive()
+
+    @patch("cpu.smee.client.requests.get")
+    def test_health_check_healthy_while_running(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = FakeResponse(_sse_lines({"body": {}}))
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+        time.sleep(0.2)
+
+        assert client.health_check() == HealthStatus.HEALTHY
+
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+    @patch("cpu.smee.client.requests.get")
+    def test_health_check_unhealthy_when_reader_thread_dies(self, mock_get: MagicMock) -> None:
+        """If the component is running but the SSE reader thread has died, report UNHEALTHY."""
+        mock_get.return_value = FakeResponse(_sse_lines({"body": {}}))
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+        time.sleep(0.2)
+
+        # Simulate the reader thread having died unexpectedly.
+        dead_thread = threading.Thread(target=lambda: None)
+        dead_thread.start()
+        dead_thread.join()
+        client._reader_thread = dead_thread
+
+        assert client.health_check() == HealthStatus.UNHEALTHY
+
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+    def test_health_check_unhealthy_before_start(self) -> None:
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+        assert client.health_check() == HealthStatus.UNHEALTHY
+
+    def test_start_before_initialize_raises(self) -> None:
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        with pytest.raises(RuntimeError):
+            client.start()
+
+    def test_stop_without_start_is_safe(self) -> None:
+        """
+        stop() before start() should not raise (no response, no reader
+        thread to clean up). State becomes STOPPING, since STOPPED is only
+        set by the start() loop when it observes the stop request.
+        """
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+        client.stop(timeout=1)
+        assert client.get_state() == ComponentState.STOPPING
+
+    @patch("cpu.smee.client.requests.get")
+    def test_stop_handles_response_close_error(self, mock_get: MagicMock) -> None:
+        """stop() should tolerate an exception raised while closing the SSE response."""
+        response = FakeResponse(_sse_lines({"body": {}}))
+        mock_get.return_value = response
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+        time.sleep(0.2)
+
+        with patch.object(response, "close", side_effect=RuntimeError("close failed")):
+            client.stop(timeout=2)
+
+        thread.join(timeout=2)
+        assert client.get_state() == ComponentState.STOPPED
+
+    @patch("cpu.smee.client.requests.get")
+    def test_reconnects_after_connection_error(self, mock_get: MagicMock) -> None:
+        """If requests.get raises, the reader retries instead of crashing the component."""
+        good_payload = {"body": {"ok": True}}
+        mock_get.side_effect = [
+            ConnectionError("boom"),
+            FakeResponse(_sse_lines(good_payload)),
+        ]
+
+        bus: ThreadMessageBus[Message] = ThreadMessageBus()
+        subscriber = bus.subscribe("webhook_events")
+
+        client = SmeeClientComponent(
+            name="smee",
+            message_bus=bus,
+            secrets_manager=_make_secrets_manager(),
+            reconnect_delay=0.01,
+        )
+        client.initialize()
+
+        thread = threading.Thread(target=client.start)
+        thread.start()
+
+        msg = subscriber.get(timeout=2)
+        client.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert msg.payload == good_payload
+        assert client.get_state() == ComponentState.STOPPED


### PR DESCRIPTION
## [0.0.10] - 2026-06-16

### Added

- `SmeeClientComponent`: new component with unit tests (#61)
- Python 3.13 and 3.14 to the test matrix (#60)

### Changed

- `SmeeClientComponent` is now used in `__main__.py`, with integration
  tests added/fixed (#63)
- pinned CI versions updated; GitHub Action warnings about deprecated
  Node versions fixed (#60)
- pytest coverage increased to 100% (#60)
- `terminaltexteffects` bumped to v0.15.0 (#60)

### Fixed

- location of `secrets_audit.log` made configurable, fixing fragile
  `/var/log/cpu` default for non-root deployments (#62, via #63)

### Removed

- unused `create_webhook_message()` and associated tests (#61)