### PR TITLE
Worker Pool component and task framework

### DIFF
--- a/src/cpu/components/base.py
+++ b/src/cpu/components/base.py
@@ -154,7 +154,7 @@ class RunnableComponent(ComponentInterface):
     def start(self) -> None:
         """Start the component's main loop."""
         if self.state != ComponentState.INITIALIZED:
-            raise RuntimeError(f"Component {self.name} not initialized")
+            raise RuntimeError(f"Component {self.name} not initialized (state={self.state})")
 
         self.state = ComponentState.RUNNING
         self._stop_requested = False

--- a/src/cpu/messaging/message.py
+++ b/src/cpu/messaging/message.py
@@ -41,6 +41,7 @@ class MessageType(Enum):
 
     # Worker-related
     PROCESS_FINISHED_JOB = "process_finished_job"
+    TASK_REQUEST = "task_request"
     TASK_COMPLETE = "task_complete"
 
     # Control messages

--- a/src/cpu/worker/pool.py
+++ b/src/cpu/worker/pool.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Generic worker pool component.
+
+WorkerPoolComponent knows nothing about what kind of work it performs.
+It runs a fixed number of worker threads pulling TASK_REQUEST messages
+from a task queue, dispatches each to a TaskHandler registered for the
+task's TaskType, and publishes a TASK_COMPLETE result (success or
+error) to a result queue. A single instance may serve one TaskType (a
+dedicated pool) or several (a shared pool), depending on how it is
+wired up.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+from cpu.components.base import ComponentState, HealthStatus, RunnableComponent
+from cpu.messaging.interfaces import MessageQueueInterface, QueueEmptyError
+from cpu.messaging.message import Message
+from cpu.worker.tasks.types import TaskHandler, TaskType, create_task_result
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerPoolComponent(RunnableComponent):
+    """
+    Runs a fixed-size pool of worker threads processing TASK_REQUEST messages.
+
+    Each worker thread loops: pull a task from task_queue, look up the
+    TaskHandler registered for the task's task_type, call handle(context),
+    and publish a TASK_COMPLETE result to result_queue. Handler exceptions
+    and unregistered task types both produce an error result rather than
+    crashing the worker thread.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        task_queue: MessageQueueInterface[Message],
+        result_queue: MessageQueueInterface[Message],
+        handlers: dict[TaskType, TaskHandler],
+        num_workers: int = 1,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Create the worker pool component.
+
+        Args:
+            name: Component name
+            task_queue: Queue to pull TASK_REQUEST messages from
+            result_queue: Queue to publish TASK_COMPLETE results to
+            handlers: TaskHandler registered per TaskType this pool serves
+            num_workers: Number of worker threads
+            config: Optional configuration dictionary
+        """
+        super().__init__(name, config)
+        self.task_queue = task_queue
+        self.result_queue = result_queue
+        self.handlers = handlers
+        self.num_workers = num_workers
+
+        self._worker_threads: list[threading.Thread] = []
+        self._worker_stop = threading.Event()
+
+    def initialize(self) -> None:
+        """
+        Validate configuration and prepare internal state.
+
+        Raises:
+            ValueError: If handlers is empty or num_workers is not positive
+        """
+        if not self.handlers:
+            raise ValueError(f"{self.name}: at least one TaskHandler must be registered")
+        if self.num_workers < 1:
+            raise ValueError(f"{self.name}: num_workers must be >= 1, got {self.num_workers}")
+
+        self.state = ComponentState.INITIALIZED
+        logger.info(
+            f"Initialized {self.name} with {self.num_workers} worker(s) "
+            f"for task types: {[t.value for t in self.handlers]}"
+        )
+
+    def start(self) -> None:
+        """Transition to RUNNING, then start worker threads, then run the main loop."""
+        if self.state != ComponentState.INITIALIZED:
+            raise RuntimeError(f"Component {self.name} not initialized (state={self.state})")
+
+        self.state = ComponentState.RUNNING
+        self._stop_requested = False
+
+        self._worker_stop.clear()
+        self._worker_threads = [
+            threading.Thread(
+                target=self._worker_loop,
+                name=f"{self.name}-worker-{worker_index}",
+                daemon=True,
+            )
+            for worker_index in range(self.num_workers)
+        ]
+        for worker_thread in self._worker_threads:
+            worker_thread.start()
+
+        logger.info(f"Starting component: {self.name}")
+
+        try:
+            while not self._stop_requested:
+                self.process_iteration()
+        except Exception as err:
+            self.state = ComponentState.FAILED
+            raise err
+        else:
+            self.state = ComponentState.STOPPED
+
+    def stop(self, timeout: float | None = None) -> None:
+        """
+        Stop the component and all worker threads.
+
+        Args:
+            timeout: Maximum time to wait for each worker thread to stop
+        """
+        super().stop(timeout)
+
+        self._worker_stop.set()
+        for worker_thread in self._worker_threads:
+            worker_thread.join(timeout=timeout)
+
+    def process_iteration(self) -> None:
+        """Main loop has no work of its own; the worker threads do the work."""
+        self._worker_stop.wait(timeout=0.1)
+
+    def health_check(self) -> HealthStatus:
+        """
+        Check component health.
+
+        Returns:
+            HEALTHY if running and all worker threads are alive,
+            UNHEALTHY otherwise.
+        """
+        if not self.is_running():
+            return HealthStatus.UNHEALTHY
+        if not self._worker_threads or any(not thread.is_alive() for thread in self._worker_threads):
+            return HealthStatus.UNHEALTHY
+        return HealthStatus.HEALTHY
+
+    def _worker_loop(self) -> None:
+        """Pull tasks from task_queue, dispatch to handlers, publish results."""
+        while not self._worker_stop.is_set():
+            try:
+                task = self.task_queue.get(timeout=0.1)
+            except QueueEmptyError:
+                continue
+
+            result_msg = self._process_task(task)
+            self.result_queue.put(result_msg)
+
+    def _process_task(self, task: Message) -> Message:
+        """Dispatch a single task to its handler, producing a result message."""
+        task_type = task.payload.get("task_type")
+        context = task.payload.get("context", {})
+
+        if not isinstance(task_type, TaskType):
+            label = repr(task_type)
+            logger.warning(f"{self.name}: no handler registered for task_type={label}")
+            return create_task_result(
+                task,
+                status="error",
+                error=f"no handler registered for task_type={label}",
+                source=self.name,
+            )
+
+        handler = self.handlers.get(task_type)
+        if handler is None:
+            label = task_type.value
+            logger.warning(f"{self.name}: no handler registered for task_type={label}")
+            return create_task_result(
+                task,
+                status="error",
+                error=f"no handler registered for task_type={label}",
+                source=self.name,
+            )
+
+        try:
+            result = handler.handle(context)
+        except Exception as err:  # noqa: BLE001 - any handler failure becomes an error result
+            logger.warning(f"{self.name}: handler for {task_type.value} failed: {err}")
+            return create_task_result(task, status="error", error=str(err), source=self.name)
+
+        return create_task_result(task, status="success", result=result, source=self.name)

--- a/src/cpu/worker/tasks/types.py
+++ b/src/cpu/worker/tasks/types.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Task definitions for the worker pool.
+
+A WorkerPoolComponent is generic: it knows nothing about what kind of
+work it performs. The actual work is delegated to one or more injected
+TaskHandlers, registered per TaskType. A single WorkerPoolComponent
+instance may serve one TaskType (a dedicated pool) or several (a
+shared pool for low-volume/low-effort task types) — which TaskTypes
+share a pool, and how many worker threads each pool has, is a wiring
+decision made when components are constructed, not something
+WorkerPoolComponent or TaskHandler need to know about.
+
+Task and result messages carry a free-form ``context`` dict through
+unmodified, so any consumer (event handler, future notifier, etc.) can
+correlate a result with the repository/PR/job it relates to, without
+WorkerPoolComponent or TaskHandler needing to know about consumers.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Literal
+
+from cpu.messaging.message import Message, MessageType
+
+
+class TaskType(Enum):
+    """
+    Types of work a worker pool can perform.
+
+    Each TaskType is served by a registered TaskHandler within one or
+    more WorkerPoolComponent instances (a pool may serve a single
+    TaskType or several).
+    """
+
+    # Webhook intake
+    VALIDATE_WEBHOOK = "validate_webhook"
+    PROCESS_COMMENT = "process_comment"
+
+    # Build/deploy actions
+    BUILD_REQUEST = "build_request"
+    DEPLOY_ARTEFACTS = "deploy_artefacts"
+    CANCEL_JOBS = "cancel_jobs"
+    CHECK_BUILD_STATUS = "check_build_status"
+    SIGN_TARBALL = "sign_tarball"
+    UPLOAD_TARBALL = "upload_tarball"
+
+    # Informational comment responses
+    SHOW_HELP = "show_help"
+    SHOW_BUILDS_STATUS = "show_builds_status"
+    SHOW_CONFIG = "show_config"
+
+    # PR lifecycle
+    PROCESS_CLOSED_PR = "process_closed_pr"
+
+
+class TaskHandler(ABC):
+    """
+    Performs the actual work for one TaskType.
+
+    Implementations are injected into a WorkerPoolComponent, keeping
+    the pool itself generic and the task-specific logic (e.g. signing
+    with a private key, uploading to a remote store, scanning job
+    directories) independently testable.
+    """
+
+    @abstractmethod
+    def handle(self, context: dict[str, Any]) -> dict[str, Any]:
+        """
+        Execute the task described by context.
+
+        Args:
+            context: Free-form task context (e.g. repository, pr_number,
+                comment_id, job_id, event_info, ...)
+
+        Returns:
+            Result data on success.
+
+        Raises:
+            Exception: Any exception indicates task failure. The worker
+                pool catches it and publishes an error result; it is not
+                propagated to the caller.
+        """
+        pass
+
+
+def create_task_request(
+    task_type: TaskType, context: dict[str, Any], source: str | None = None
+) -> Message:
+    """
+    Create a task request message for a worker pool's task queue.
+
+    Args:
+        task_type: The kind of work requested. Required so that pools
+            serving multiple TaskTypes can dispatch to the right handler.
+        context: Free-form task context, passed through unmodified to
+            the TaskHandler and echoed back in the result message.
+        source: Optional name of the producing component.
+
+    Returns:
+        Message of type TASK_REQUEST
+    """
+    return Message(
+        type=MessageType.TASK_REQUEST,
+        payload={"task_type": task_type, "context": context},
+        source=source,
+    )
+
+
+def create_task_result(
+    task: Message,
+    status: Literal["success", "error"],
+    result: dict[str, Any] | None = None,
+    error: str | None = None,
+    source: str | None = None,
+) -> Message:
+    """
+    Create a task result message, linked back to the originating task.
+
+    Args:
+        task: The original TASK_REQUEST message this result responds to
+        status: "success" or "error"
+        result: Result data (only included when status="success")
+        error: Error description (only included when status="error")
+        source: Optional name of the producing component (typically the
+            worker pool's name)
+
+    Returns:
+        Message of type TASK_COMPLETE, with correlation_id set to the
+        originating task's id, and the task's task_type/context carried
+        through.
+
+    Raises:
+        ValueError: If status is not "success" or "error"
+    """
+    if status not in ("success", "error"):
+        raise ValueError(f"status must be 'success' or 'error', got {status!r}")
+
+    payload: dict[str, Any] = {
+        "status": status,
+        "task_type": task.payload.get("task_type"),
+        "context": task.payload.get("context", {}),
+    }
+    if status == "success":
+        payload["result"] = result if result is not None else {}
+    else:
+        payload["error"] = error if error is not None else "unknown error"
+
+    return Message(
+        type=MessageType.TASK_COMPLETE,
+        payload=payload,
+        correlation_id=task.id,
+        source=source,
+    )

--- a/tests/unit/test_worker_pool.py
+++ b/tests/unit/test_worker_pool.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Tests for cpu.worker.pool module which provides WorkerPoolComponent.
+
+WorkerPoolComponent is generic: it runs a fixed number of worker
+threads pulling TASK_REQUEST messages from a task queue, dispatches
+each to a registered TaskHandler keyed by TaskType, and publishes a
+TASK_COMPLETE result (success or error) to a result queue.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from cpu.components.base import ComponentState, HealthStatus
+from cpu.messaging.message import Message, MessageType
+from cpu.messaging.queue_thread import ThreadMessageQueue
+from cpu.worker.pool import WorkerPoolComponent
+from cpu.worker.tasks.types import TaskHandler, TaskType, create_task_request
+
+
+class RecordingHandler(TaskHandler):
+    """TaskHandler that records calls and returns/raises a fixed outcome."""
+
+    def __init__(self, result: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+        self.result = result if result is not None else {}
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
+
+    def handle(self, context: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            self.calls.append(context)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class SlowHandler(TaskHandler):
+    """TaskHandler that blocks until released, to test concurrency."""
+
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def handle(self, context: dict[str, Any]) -> dict[str, Any]:
+        self.started.set()
+        self.release.wait(timeout=2)
+        return {"context": context}
+
+
+class TestWorkerPoolComponentInitialization:
+    """Tests for initialization and validation."""
+
+    def test_initialization_sets_state(self) -> None:
+        task_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        result_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=task_queue,
+            result_queue=result_queue,
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+        )
+        pool.initialize()
+        assert pool.get_state() == ComponentState.INITIALIZED
+
+    def test_rejects_empty_handlers(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={},
+        )
+        with pytest.raises(ValueError):
+            pool.initialize()
+
+    def test_rejects_non_positive_num_workers(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+            num_workers=0,
+        )
+        with pytest.raises(ValueError):
+            pool.initialize()
+
+    def test_default_num_workers_is_one(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+        )
+        assert pool.num_workers == 1
+
+
+class TestWorkerPoolComponentDispatch:
+    """Tests for task dispatch and result publishing."""
+
+    # TODO name is misleading? there's only one handler so how do we perform a match at all?
+    def test_dispatches_to_matching_handler(self) -> None:
+        task_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        result_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = RecordingHandler(result={"artefact": "foo.tar.gz"})
+
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=task_queue,
+            result_queue=result_queue,
+            handlers={TaskType.CHECK_BUILD_STATUS: handler},
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_dispatches_to_matching_handler"
+        )
+        thread.start()
+
+        task = create_task_request(TaskType.CHECK_BUILD_STATUS, {"job_id": "1"})
+        task_queue.put(task)
+
+        result = result_queue.get(timeout=2)
+        pool.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert handler.calls == [{"job_id": "1"}]
+        assert result.payload["status"] == "success"
+        assert result.payload["task_type"] == TaskType.CHECK_BUILD_STATUS
+        assert result.payload["result"] == {"artefact": "foo.tar.gz"}
+        assert result.correlation_id == task.id
+
+    def test_handler_exception_produces_error_result(self) -> None:
+        task_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        result_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        handler = RecordingHandler(error=RuntimeError("signing failed"))
+
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=task_queue,
+            result_queue=result_queue,
+            handlers={TaskType.SIGN_TARBALL: handler},
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_handler_exception_produces_error_result"
+        )
+        thread.start()
+
+        task_queue.put(create_task_request(TaskType.SIGN_TARBALL, {"job_id": "1"}))
+
+        result = result_queue.get(timeout=2)
+        pool.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert result.payload["status"] == "error"
+        assert "signing failed" in result.payload["error"]
+
+    def test_unregistered_task_type_produces_error_result(self) -> None:
+        task_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        result_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=task_queue,
+            result_queue=result_queue,
+            handlers={TaskType.SIGN_TARBALL: RecordingHandler()},
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_unregistered_task_type_produces_error_result"
+        )
+        thread.start()
+
+        # UPLOAD_TARBALL has no registered handler in this pool.
+        task_queue.put(create_task_request(TaskType.UPLOAD_TARBALL, {"job_id": "1"}))
+
+        result = result_queue.get(timeout=2)
+        pool.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert result.payload["status"] == "error"
+        assert "upload_tarball" in result.payload["error"].lower()
+
+    def test_missing_task_type_produces_error_result(self) -> None:
+        task_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        result_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=task_queue,
+            result_queue=result_queue,
+            handlers={TaskType.SIGN_TARBALL: RecordingHandler()},
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_missing_task_type_produces_error_result"
+        )
+        thread.start()
+
+        # A malformed task message with no usable task_type at all.
+        task_queue.put(Message(type=MessageType.TASK_REQUEST, payload={"context": {}}))
+
+        result = result_queue.get(timeout=2)
+        pool.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert result.payload["status"] == "error"
+        assert "no handler registered" in result.payload["error"].lower()
+
+    def test_pool_serving_multiple_task_types(self) -> None:
+        task_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        result_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        help_handler = RecordingHandler(result={"text": "help"})
+        status_handler = RecordingHandler(result={"text": "status"})
+
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=task_queue,
+            result_queue=result_queue,
+            handlers={
+                TaskType.SHOW_HELP: help_handler,
+                TaskType.SHOW_BUILDS_STATUS: status_handler,
+            },
+            num_workers=2,
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_pool_serving_multiple_task_types"
+        )
+        thread.start()
+
+        task_queue.put(create_task_request(TaskType.SHOW_HELP, {"pr": 1}))
+        task_queue.put(create_task_request(TaskType.SHOW_BUILDS_STATUS, {"pr": 2}))
+
+        results = {result_queue.get(timeout=2).payload["task_type"] for _ in range(2)}
+
+        pool.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert results == {TaskType.SHOW_HELP, TaskType.SHOW_BUILDS_STATUS}
+        assert help_handler.calls == [{"pr": 1}]
+        assert status_handler.calls == [{"pr": 2}]
+
+    def test_multiple_workers_process_concurrently(self) -> None:
+        task_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        result_queue: ThreadMessageQueue[Message] = ThreadMessageQueue()
+        slow_a = SlowHandler()
+        slow_b = SlowHandler()
+
+        # Two distinct task types sharing one pool with 2 workers, so
+        # both slow handlers can be in-flight at the same time.
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=task_queue,
+            result_queue=result_queue,
+            handlers={TaskType.SIGN_TARBALL: slow_a, TaskType.UPLOAD_TARBALL: slow_b},
+            num_workers=2,
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_multiple_workers_process_concurrently"
+        )
+        thread.start()
+
+        task_queue.put(create_task_request(TaskType.SIGN_TARBALL, {"job_id": "a"}))
+        task_queue.put(create_task_request(TaskType.UPLOAD_TARBALL, {"job_id": "b"}))
+
+        assert slow_a.started.wait(timeout=2)
+        assert slow_b.started.wait(timeout=2)
+
+        slow_a.release.set()
+        slow_b.release.set()
+
+        result_queue.get(timeout=2)
+        result_queue.get(timeout=2)
+
+        pool.stop(timeout=2)
+        thread.join(timeout=2)
+
+
+class TestWorkerPoolComponentLifecycle:
+    """Tests for start/stop lifecycle and health checks."""
+
+    def test_start_before_initialize_raises(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+        )
+        with pytest.raises(RuntimeError):
+            pool.start()
+
+    def test_process_iteration_exception_sets_failed_state(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+        )
+        pool.initialize()
+        pool.process_iteration = lambda: (_ for _ in ()).throw(RuntimeError("boom"))  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="boom"):
+            pool.start()
+
+        assert pool.get_state() == ComponentState.FAILED
+
+    def test_stop_terminates_cleanly(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+            num_workers=3,
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_stop_terminates_cleanly"
+        )
+        thread.start()
+        time.sleep(0.2)
+
+        pool.stop(timeout=2)
+        thread.join(timeout=2)
+
+        assert pool.get_state() == ComponentState.STOPPED
+        assert not thread.is_alive()
+
+    def test_health_check_unhealthy_before_start(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+        )
+        pool.initialize()
+        assert pool.health_check() == HealthStatus.UNHEALTHY
+
+    def test_health_check_healthy_while_running(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+            num_workers=2,
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_health_check_healthy_while_running"
+        )
+        thread.start()
+        time.sleep(0.2)
+
+        assert pool.health_check() == HealthStatus.HEALTHY
+
+        pool.stop(timeout=2)
+        thread.join(timeout=2)
+
+    def test_health_check_unhealthy_when_a_worker_thread_dies(self) -> None:
+        pool = WorkerPoolComponent(
+            name="pool",
+            task_queue=ThreadMessageQueue(),
+            result_queue=ThreadMessageQueue(),
+            handlers={TaskType.CHECK_BUILD_STATUS: RecordingHandler()},
+            num_workers=2,
+        )
+        pool.initialize()
+
+        thread = threading.Thread(
+            target=pool.start, name="test_health_check_unhealthy_when_a_worker_thread_dies"
+        )
+        thread.start()
+        time.sleep(0.2)
+
+        dead_thread = threading.Thread(target=lambda: None, name="dead_thread_stub")
+        dead_thread.start()
+        dead_thread.join()
+        pool._worker_threads[0] = dead_thread
+
+        assert pool.health_check() == HealthStatus.UNHEALTHY
+
+        pool.stop(timeout=2)
+        thread.join(timeout=2)

--- a/tests/unit/test_worker_tasks_types.py
+++ b/tests/unit/test_worker_tasks_types.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Tests for cpu.worker.tasks module: TaskType enum, TaskHandler interface,
+and task/result message factory helpers used by WorkerPoolComponent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cpu.messaging.message import MessageType
+from cpu.worker.tasks.types import (
+    TaskHandler,
+    TaskType,
+    create_task_request,
+    create_task_result,
+)
+
+
+class TestTaskType:
+    """Tests for the TaskType enum."""
+
+    @pytest.mark.parametrize(
+        ("member", "value"),
+        [
+            (TaskType.VALIDATE_WEBHOOK, "validate_webhook"),
+            (TaskType.PROCESS_COMMENT, "process_comment"),
+            (TaskType.BUILD_REQUEST, "build_request"),
+            (TaskType.DEPLOY_ARTEFACTS, "deploy_artefacts"),
+            (TaskType.CANCEL_JOBS, "cancel_jobs"),
+            (TaskType.CHECK_BUILD_STATUS, "check_build_status"),
+            (TaskType.SIGN_TARBALL, "sign_tarball"),
+            (TaskType.UPLOAD_TARBALL, "upload_tarball"),
+            (TaskType.SHOW_HELP, "show_help"),
+            (TaskType.SHOW_BUILDS_STATUS, "show_builds_status"),
+            (TaskType.SHOW_CONFIG, "show_config"),
+            (TaskType.PROCESS_CLOSED_PR, "process_closed_pr"),
+        ],
+    )
+    def test_task_type_value(self, member: TaskType, value: str) -> None:
+        assert member.value == value
+
+
+class RecordingHandler(TaskHandler):
+    """Minimal concrete TaskHandler for interface tests."""
+
+    def __init__(self, result: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+        self.result = result if result is not None else {}
+        self.error = error
+        self.received: dict[str, Any] | None = None
+
+    def handle(self, context: dict[str, Any]) -> dict[str, Any]:
+        self.received = context
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class TestTaskHandlerInterface:
+    """Tests for the TaskHandler abstract interface."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        with pytest.raises(TypeError):
+            TaskHandler()  # type: ignore[abstract]
+
+    def test_concrete_handler_returns_result(self) -> None:
+        handler = RecordingHandler(result={"status": "ok"})
+        result = handler.handle({"job_id": "123"})
+        assert result == {"status": "ok"}
+        assert handler.received == {"job_id": "123"}
+
+    def test_concrete_handler_can_raise(self) -> None:
+        handler = RecordingHandler(error=RuntimeError("boom"))
+        with pytest.raises(RuntimeError, match="boom"):
+            handler.handle({"job_id": "123"})
+
+
+class TestCreateTaskRequest:
+    """Tests for create_task_request."""
+
+    def test_creates_task_request_message(self) -> None:
+        context = {"job_id": "123", "repository": "EESSI/cpu"}
+        msg = create_task_request(TaskType.CHECK_BUILD_STATUS, context)
+
+        assert msg.type == MessageType.TASK_REQUEST
+        assert msg.payload["task_type"] == TaskType.CHECK_BUILD_STATUS
+        assert msg.payload["context"] == context
+
+    def test_default_source(self) -> None:
+        msg = create_task_request(TaskType.CHECK_BUILD_STATUS, {"job_id": "123"})
+        assert msg.source is None
+
+    def test_custom_source(self) -> None:
+        msg = create_task_request(
+            TaskType.CHECK_BUILD_STATUS, {"job_id": "123"}, source="job_manager"
+        )
+        assert msg.source == "job_manager"
+
+    def test_context_is_passed_through_unmodified(self) -> None:
+        context = {
+            "repository": "EESSI/cpu",
+            "pr_number": 42,
+            "comment_id": 9999,
+            "job_id": "job_1",
+            "event_info": {"action": "opened"},
+        }
+        msg = create_task_request(TaskType.BUILD_REQUEST, context)
+        assert msg.payload["context"] == context
+
+    def test_different_task_types_are_distinguishable(self) -> None:
+        sign_msg = create_task_request(TaskType.SIGN_TARBALL, {"job_id": "1"})
+        upload_msg = create_task_request(TaskType.UPLOAD_TARBALL, {"job_id": "1"})
+        assert sign_msg.payload["task_type"] != upload_msg.payload["task_type"]
+
+
+class TestCreateTaskResult:
+    """Tests for create_task_result."""
+
+    def test_success_result(self) -> None:
+        context = {"job_id": "123"}
+        task = create_task_request(TaskType.SIGN_TARBALL, context)
+
+        result_msg = create_task_result(
+            task, status="success", result={"artefact": "foo.tar.gz"}
+        )
+
+        assert result_msg.type == MessageType.TASK_COMPLETE
+        assert result_msg.payload["status"] == "success"
+        assert result_msg.payload["task_type"] == TaskType.SIGN_TARBALL
+        assert result_msg.payload["context"] == context
+        assert result_msg.payload["result"] == {"artefact": "foo.tar.gz"}
+        assert "error" not in result_msg.payload
+
+    def test_error_result(self) -> None:
+        context = {"job_id": "123"}
+        task = create_task_request(TaskType.UPLOAD_TARBALL, context)
+
+        result_msg = create_task_result(task, status="error", error="boom")
+
+        assert result_msg.type == MessageType.TASK_COMPLETE
+        assert result_msg.payload["status"] == "error"
+        assert result_msg.payload["task_type"] == TaskType.UPLOAD_TARBALL
+        assert result_msg.payload["context"] == context
+        assert result_msg.payload["error"] == "boom"
+        assert "result" not in result_msg.payload
+
+    def test_result_correlation_id_links_to_task(self) -> None:
+        task = create_task_request(TaskType.CHECK_BUILD_STATUS, {"job_id": "123"})
+        result_msg = create_task_result(task, status="success", result={})
+        assert result_msg.correlation_id == task.id
+
+    def test_custom_source(self) -> None:
+        task = create_task_request(TaskType.SIGN_TARBALL, {"job_id": "123"})
+        result_msg = create_task_result(
+            task, status="success", result={}, source="worker_pool_sign"
+        )
+        assert result_msg.source == "worker_pool_sign"
+
+    def test_invalid_status_raises(self) -> None:
+        task = create_task_request(TaskType.CHECK_BUILD_STATUS, {"job_id": "123"})
+        with pytest.raises(ValueError):
+            create_task_result(task, status="bogus")  # type: ignore[arg-type]


### PR DESCRIPTION
## Worker Pool component and task framework

Adds the generic `WorkerPoolComponent` along with the `TaskType`/`TaskHandler` framework it depends on.

### What's new

- `TaskType` enum (`src/cpu/worker/tasks/types.py`): the full set of task kinds for webhook intake, build/deploy actions, informational comment responses, and PR lifecycle handling.
- `TaskHandler` ABC: pluggable, single-method interface (`handle(context) -> dict`) for task-specific logic, injected into the pool rather than hardcoded.
- `create_task_request` / `create_task_result`: message factories for submitting tasks and reporting results, linked via `correlation_id`.
- `WorkerPoolComponent` (`src/cpu/worker/pool.py`): runs a configurable number of worker threads pulling `TASK_REQUEST` messages from a task queue, dispatching to the registered handler for each task's `TaskType`, and publishing `TASK_COMPLETE` results (success or error) to a result queue. A single pool instance may serve one or several `TaskType`s, depending on how it's wired.
- `MessageType.TASK_REQUEST` added alongside the existing `TASK_COMPLETE`.

### Design notes

- The pool is intentionally generic: it has no knowledge of what kind of work it runs; all task-specific behavior lives in injected `TaskHandler` implementations.
- Handler exceptions and unregistered/missing task types both produce error results rather than crashing a worker thread.
- `start()` transitions to `RUNNING` and spawns worker threads atomically before running the main loop, avoiding a race where workers could complete work and trigger `stop()` before the component's own state left `INITIALIZED`.

### Testing

40 new unit tests across `test_worker_pool.py` and `test_worker_tasks_types.py`; `pool.py` and `tasks/types.py` at 100% coverage.