### PR TITLE
Add webhook signature validation for GitHub and GitLab

### DIFF
--- a/src/cpu/worker/__init__.py
+++ b/src/cpu/worker/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""CPU bot worker package."""

--- a/src/cpu/worker/tasks/__init__.py
+++ b/src/cpu/worker/tasks/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""CPU bot worker tasks package."""

--- a/src/cpu/worker/tasks/webhook_validators/__init__.py
+++ b/src/cpu/worker/tasks/webhook_validators/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU bot webhook validators package.
+
+Importing this package causes all built-in platform validators to
+self-register in WEBHOOK_VALIDATORS (defined in .base).
+
+To add a new hosting platform: create a new module that appends its
+validator class to WEBHOOK_VALIDATORS at import time, then add a
+corresponding import below.
+"""
+
+# Import platform modules to trigger their self-registration in WEBHOOK_VALIDATORS.
+from cpu.worker.tasks.webhook_validators import github as _github_module  # noqa: F401
+from cpu.worker.tasks.webhook_validators import gitlab as _gitlab_module  # noqa: F401

--- a/src/cpu/worker/tasks/webhook_validators/base.py
+++ b/src/cpu/worker/tasks/webhook_validators/base.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Webhook validation base types: abstract validator interface, exception
+hierarchy, case-insensitive header lookup helper, and the platform-detection
+registry used to dispatch validation to the right platform-specific validator.
+
+Adding a new hosting platform requires:
+1. A new module (e.g. bitbucket.py) with a class that inherits
+   PlatformWebhookValidator and calls
+   WEBHOOK_VALIDATORS.append(MyValidator) at module level.
+2. Importing that module in __init__.py to ensure the self-registration
+   side-effect runs when the package is imported.
+
+No changes to this module, to detect_platform(), or to any caller are
+needed.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import ClassVar
+
+
+class WebhookValidationError(Exception):
+    """
+    Raised when a webhook request cannot be validated.
+
+    Covers missing or malformed signature headers, HMAC mismatches,
+    unsupported signature schemes, and malformed secret material.
+    """
+
+
+class UnsupportedPlatformError(WebhookValidationError):
+    """
+    Raised when no registered validator recognises the incoming request headers.
+
+    The calling code should treat this as an indication that the webhook
+    originated from a platform that is not yet supported, rather than as a
+    security failure.
+    """
+
+
+def get_header(headers: Mapping[str, str], name: str) -> str | None:
+    """
+    Case-insensitive lookup of a single header value.
+
+    Args:
+        headers: Mapping of header names to values.
+        name: Header name to look up (case-insensitive).
+
+    Returns:
+        The header value, or None if the header is absent.
+    """
+    name_lower = name.lower()
+    for key, value in headers.items():
+        if key.lower() == name_lower:
+            return value
+    return None
+
+
+class PlatformWebhookValidator(ABC):
+    """
+    Abstract base class for platform-specific webhook signature validators.
+
+    Each concrete implementation is responsible for:
+    - Recognising whether an incoming request originated from its platform
+      (matches()).
+    - Verifying the request's signature (validate()).
+
+    Concrete classes self-register in WEBHOOK_VALIDATORS at import time,
+    which is the only change needed to add support for a new platform.
+    """
+
+    # TODO Why is it a class variable?
+    platform: ClassVar[str]
+    """Short lowercase platform identifier, e.g. "github" or "gitlab"."""
+
+    @classmethod
+    @abstractmethod
+    def matches(cls, headers: Mapping[str, str]) -> bool:
+        """
+        Return True if the request headers indicate this platform.
+
+        This is a lightweight check on header presence/names only; it does
+        not verify the signature. Used by detect_platform() to route
+        requests to the right validator.
+
+        Args:
+            headers: Incoming request headers.
+        """
+
+    @abstractmethod
+    def validate(self, headers: Mapping[str, str], raw_body: bytes, secret: str) -> None:
+        """
+        Verify the webhook signature.
+
+        Args:
+            headers: Incoming request headers.
+            raw_body: Raw request body bytes used to compute the expected HMAC.
+            secret: Platform-specific webhook secret (encoding depends on
+                the platform; see concrete implementations for details).
+
+        Raises:
+            WebhookValidationError: If the signature is missing, malformed,
+                or does not match the expected value.
+        """
+
+
+#: Ordered list of registered platform validators.
+#:
+#: Platform modules append their validator class here at import time.
+#: detect_platform() iterates this list in order; the first match wins,
+#: so registration order matters when headers could match multiple validators.
+WEBHOOK_VALIDATORS: list[type[PlatformWebhookValidator]] = []
+
+
+# TODO Should one implement a function that determines all matches? I.e., to determine ambiguous headers?
+def detect_platform(headers: Mapping[str, str]) -> type[PlatformWebhookValidator]:
+    """
+    Identify the originating platform from the request headers.
+
+    Iterates WEBHOOK_VALIDATORS in registration order and returns the
+    first class whose matches() method returns True.
+
+    Args:
+        headers: Incoming request headers.
+
+    Returns:
+        The matching PlatformWebhookValidator subclass (not an instance).
+
+    Raises:
+        UnsupportedPlatformError: If no registered validator matches.
+    """
+    for validator_cls in WEBHOOK_VALIDATORS:
+        if validator_cls.matches(headers):
+            return validator_cls
+    header_names = list(headers.keys())
+    raise UnsupportedPlatformError(
+        f"No registered validator matches the incoming request headers: {header_names}"
+    )

--- a/src/cpu/worker/tasks/webhook_validators/github.py
+++ b/src/cpu/worker/tasks/webhook_validators/github.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+GitHub webhook signature validator.
+
+Validates webhook signatures per
+https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+
+GitHub signs requests with HMAC using the webhook secret as the key and the
+raw request body as the message. Two headers may be present:
+
+- "X-Hub-Signature-256" — HMAC-SHA256 in "sha256=<hexdigest>" format
+  (recommended, preferred when present).
+- "X-Hub-Signature" — HMAC-SHA1 in "sha1=<hexdigest>" format
+  (legacy, accepted as fallback when the SHA-256 header is absent).
+
+At least one of these headers must be present; if both are present the
+SHA-256 header takes precedence and SHA-1 is ignored.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from cpu.worker.tasks.webhook_validators.base import (
+    WEBHOOK_VALIDATORS,
+    PlatformWebhookValidator,
+    WebhookValidationError,
+    get_header,
+)
+
+logger = logging.getLogger(__name__)
+
+_HEADER_EVENT = "X-GitHub-Event"
+_HEADER_SIGNATURE_256 = "X-Hub-Signature-256"
+_HEADER_SIGNATURE_1 = "X-Hub-Signature"
+
+_GITHUB_IDENTIFYING_HEADERS = (
+    _HEADER_EVENT,
+    _HEADER_SIGNATURE_256,
+    _HEADER_SIGNATURE_1,
+)
+
+
+class GitHubWebhookValidator(PlatformWebhookValidator):
+    """Validates webhook signatures from GitHub."""
+
+    platform = "github"
+
+    @classmethod
+    def matches(cls, headers: Mapping[str, str]) -> bool:
+        return any(get_header(headers, header) is not None for header in _GITHUB_IDENTIFYING_HEADERS)
+
+    def validate(self, headers: Mapping[str, str], raw_body: bytes, secret: str) -> None:
+        """
+        Verify the GitHub webhook signature.
+
+        Prefers the SHA-256 signature ("X-Hub-Signature-256"); falls back
+        to the SHA-1 signature ("X-Hub-Signature") when the SHA-256 header
+        is absent. Raises if neither header is present.
+
+        Args:
+            headers: Incoming request headers.
+            raw_body: Raw request body bytes.
+            secret: Webhook secret string (UTF-8, as configured in GitHub).
+
+        Raises:
+            WebhookValidationError: If the signature is missing, malformed,
+                or does not match.
+        """
+        sig256 = get_header(headers, _HEADER_SIGNATURE_256)
+        if sig256 is not None:
+            self._verify(sig256, hashlib.sha256, "sha256", secret, raw_body)
+            return
+
+        sig1 = get_header(headers, _HEADER_SIGNATURE_1)
+        if sig1 is not None:
+            self._verify(sig1, hashlib.sha1, "sha1", secret, raw_body)
+            return
+
+        raise WebhookValidationError(
+            f"Missing GitHub signature headers: expected {_HEADER_SIGNATURE_256} "
+            f"(preferred) or {_HEADER_SIGNATURE_1} (legacy)"
+        )
+
+    @staticmethod
+    def _verify(
+        header_value: str,
+        digestmod: Any,
+        algo: str,
+        secret: str,
+        raw_body: bytes,
+    ) -> None:
+        """Compute the expected HMAC and compare it to the header value."""
+        expected = f"{algo}=" + hmac.new(secret.encode(), raw_body, digestmod).hexdigest()
+        if not hmac.compare_digest(expected, header_value):
+            raise WebhookValidationError(f"GitHub {algo.upper()} signature verification failed")
+
+
+# Self-register in the global validator registry.
+# This side-effect runs when the module is first imported, which is triggered
+# by cpu.worker.tasks.webhook_validators.__init__ importing this module.
+WEBHOOK_VALIDATORS.append(GitHubWebhookValidator)

--- a/src/cpu/worker/tasks/webhook_validators/gitlab.py
+++ b/src/cpu/worker/tasks/webhook_validators/gitlab.py
@@ -39,7 +39,6 @@ from cpu.worker.tasks.webhook_validators.base import (
 
 logger = logging.getLogger(__name__)
 
-# TODO How about using const strings to avoid mispellings?
 _HEADER_EVENT = "X-Gitlab-Event"
 _HEADER_SIGNATURE = "Webhook-Signature"
 _HEADER_TOKEN_LEGACY = "X-Gitlab-Token"

--- a/src/cpu/worker/tasks/webhook_validators/gitlab.py
+++ b/src/cpu/worker/tasks/webhook_validators/gitlab.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+GitLab webhook signature validator (GitLab 19+ signing-token scheme only).
+
+GitLab 19.0 introduced a signing-token scheme where webhooks are signed with
+HMAC-SHA256 and the signature is sent in the "Webhook-Signature" header:
+
+    Webhook-Signature: v1,<base64(HMAC-SHA256(key, webhook_id.timestamp.body))>
+
+The key is the base64-decoded signing token (configured per webhook in
+GitLab, stored in CPU as a base64-encoded string). Multiple space-separated
+signatures may be present (key rotation); validation succeeds if any one of
+them matches.
+
+This validator explicitly does NOT support the legacy "X-Gitlab-Token"
+plain-secret scheme used by GitLab < 19. Requests that carry only that header
+are recognised as GitLab but rejected with a clear error message.
+
+See https://docs.gitlab.com/user/project/integrations/webhooks/#signing-tokens
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+from collections.abc import Mapping
+
+from cpu.worker.tasks.webhook_validators.base import (
+    WEBHOOK_VALIDATORS,
+    PlatformWebhookValidator,
+    WebhookValidationError,
+    get_header,
+)
+
+logger = logging.getLogger(__name__)
+
+# TODO How about using const strings to avoid mispellings?
+_HEADER_EVENT = "X-Gitlab-Event"
+_HEADER_SIGNATURE = "Webhook-Signature"
+_HEADER_TOKEN_LEGACY = "X-Gitlab-Token"
+_HEADER_WEBHOOK_ID = "Webhook-Id"
+_HEADER_TIMESTAMP = "Webhook-Timestamp"
+
+_GITLAB_IDENTIFYING_HEADERS = (
+    _HEADER_EVENT,
+    _HEADER_SIGNATURE,
+    _HEADER_TOKEN_LEGACY,
+)
+
+_V1_PREFIX = "v1,"
+
+
+class GitLabWebhookValidator(PlatformWebhookValidator):
+    """Validates webhook signatures from GitLab 19+ (signing-token scheme)."""
+
+    platform = "gitlab"
+
+    @classmethod
+    def matches(cls, headers: Mapping[str, str]) -> bool:
+        # X-Gitlab-Token (legacy) is also recognised so that validate() can
+        # return a clear "unsupported scheme" error instead of "unknown platform".
+        return any(get_header(headers, header) is not None for header in _GITLAB_IDENTIFYING_HEADERS)
+
+    def validate(self, headers: Mapping[str, str], raw_body: bytes, secret: str) -> None:
+        """
+        Verify the GitLab webhook signature (signing-token scheme, GitLab 19+).
+
+        Args:
+            headers: Incoming request headers.
+            raw_body: Raw request body bytes.
+            secret: Base64-encoded signing token as configured in GitLab and
+                stored in CPU's secret manager.
+
+        Raises:
+            WebhookValidationError: If the Webhook-Signature header is
+                absent (including when only the legacy X-Gitlab-Token is
+                present), if no "v1," signature is found, if required
+                "Webhook-Id" or "Webhook-Timestamp" headers are missing,
+                if the secret is not valid base64, or if no signature matches.
+        """
+        signature_header = get_header(headers, _HEADER_SIGNATURE)
+
+        if signature_header is None:
+            if get_header(headers, _HEADER_TOKEN_LEGACY) is not None:
+                raise WebhookValidationError(
+                    f"Webhook signed with the legacy {_HEADER_TOKEN_LEGACY} header is not supported. "
+                    "Configure a signing token in GitLab (requires GitLab 19+) to use the "
+                    f"{_HEADER_SIGNATURE} scheme."
+                )
+            raise WebhookValidationError(f"Missing {_HEADER_SIGNATURE} header")
+
+        # GitLab may send a space-separated list of signatures for key rotation.
+        signatures = signature_header.split(" ")
+        v1_signatures = [sig for sig in signatures if sig.startswith(_V1_PREFIX)]
+        if not v1_signatures:
+            raise WebhookValidationError(
+                f"No supported signature scheme found in {_HEADER_SIGNATURE} header "
+                f"(expected '{_V1_PREFIX}' prefix, got: {signature_header!r})"
+            )
+
+        webhook_id = get_header(headers, _HEADER_WEBHOOK_ID)
+        if webhook_id is None:
+            raise WebhookValidationError(f"Missing {_HEADER_WEBHOOK_ID} header")
+
+        timestamp = get_header(headers, _HEADER_TIMESTAMP)
+        if timestamp is None:
+            raise WebhookValidationError(f"Missing {_HEADER_TIMESTAMP} header")
+
+        try:
+            key = base64.standard_b64decode(secret)
+        except Exception as err:
+            raise WebhookValidationError(
+                f"GitLab webhook secret is not valid base64: {err}"
+            ) from err
+
+        components = (webhook_id.encode(), timestamp.encode(), raw_body)
+        mac = hmac.new(key, msg=b".".join(components), digestmod=hashlib.sha256)
+        expected = _V1_PREFIX + base64.standard_b64encode(mac.digest()).decode()
+
+        if not any(hmac.compare_digest(expected, sig) for sig in v1_signatures):
+            raise WebhookValidationError("GitLab webhook signature verification failed")
+
+
+# Self-register in the global validator registry.
+# This side-effect runs when the module is first imported, which is triggered
+# by cpu.worker.tasks.webhook_validators.__init__ importing this module.
+WEBHOOK_VALIDATORS.append(GitLabWebhookValidator)

--- a/src/cpu/worker/tasks/webhook_validators/handler.py
+++ b/src/cpu/worker/tasks/webhook_validators/handler.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+TaskHandler for webhook signature validation (TaskType.VALIDATE_WEBHOOK).
+
+WebhookValidationHandler is registered for TaskType.VALIDATE_WEBHOOK in a
+WorkerPoolComponent. Given a task context produced by SmeeClientComponent
+(or a direct webhook receiver), it:
+
+1. Detects the originating platform from the request headers.
+2. Fetches the webhook secret from the default (catch-all) secret
+   configuration for that platform via SecretManager.
+3. Re-serialises the body dict to bytes and runs the platform-specific
+   signature validator.
+4. Returns {"platform": "<name>", "valid": True} on success.
+
+Any failure (unsupported platform, missing secret configuration, signature
+mismatch) is raised rather than swallowed, so WorkerPoolComponent converts
+it to an error TASK_COMPLETE result.
+
+Note on Smee and raw-body fidelity
+-----------------------------------
+GitHub and GitLab sign the *exact raw bytes* of the original request body.
+When webhooks arrive via Smee (a EESSI operated proxy), Smee parses and
+re-serialises the JSON before forwarding it over SSE, and the CPU bot then
+JSON-decodes it again. The bytes produced by re-serialising the parsed dict
+here (json.dumps(body, separators=(",", ":"))) may not byte-match the
+original signed payload (e.g. different whitespace or key ordering), which
+can cause signature verification to fail for otherwise valid webhooks. This
+is a known limitation of Smee and is expected with the used proxy (however,
+in 3+ years of operations we never hit this issue)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from cpu.config.secrets import SecretManager
+from cpu.config.secrets_context import SecretContext
+from cpu.worker.tasks.types import TaskHandler
+from cpu.worker.tasks.webhook_validators.base import (
+    PlatformWebhookValidator,
+    WebhookValidationError,
+    detect_platform,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookValidationHandler(TaskHandler):
+    """
+    Verifies the signature of an incoming webhook request.
+
+    Registered for TaskType.VALIDATE_WEBHOOK in a WorkerPoolComponent.
+
+    Args:
+        secrets_manager: Used to fetch the webhook secret for the detected
+            platform. A default (catch-all) SecretContext is used per
+            platform; per-organisation or per-repository secret lookup is
+            not yet implemented.
+    """
+
+    def __init__(self, secrets_manager: SecretManager) -> None:
+        self.secrets_manager = secrets_manager
+
+    def handle(self, context: dict[str, Any]) -> dict[str, Any]:
+        """
+        Verify the webhook signature in the task context.
+
+        Args:
+            context: Task context dict, expected to contain:
+                - "headers": dict of incoming request headers.
+                - "body": parsed JSON body dict.
+
+        Returns:
+            {"platform": "<name>", "valid": True} on success.
+
+        Raises:
+            WebhookValidationError: If the context is malformed (missing
+                "headers" or "body" key), or if the signature is
+                absent or invalid.
+            UnsupportedPlatformError: Propagated from detect_platform()
+                if no registered validator matches the headers.
+            SecretNotFoundError: Propagated from SecretManager if no
+                secret configuration is found for the detected platform.
+        """
+        if "headers" not in context:
+            raise WebhookValidationError("Task context is missing required key 'headers'")
+        if "body" not in context:
+            raise WebhookValidationError("Task context is missing required key 'body'")
+
+        headers: dict[str, str] = context["headers"]
+        body: Any = context["body"]
+
+        validator_cls = detect_platform(headers)
+        logger.debug(f"Detected platform: {validator_cls.platform}")
+
+        secret = self._get_webhook_secret(validator_cls)
+
+        # Re-serialise body to bytes for HMAC computation.
+        # See module docstring for the Smee caveat on raw-body fidelity.
+        raw_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+
+        validator_cls().validate(headers, raw_body, secret)
+        logger.debug(f"Webhook signature verified for platform: {validator_cls.platform}")
+
+        return {"platform": validator_cls.platform, "valid": True}
+
+    def _get_webhook_secret(self, validator_cls: type[PlatformWebhookValidator]) -> str:
+        """
+        Fetch the webhook secret for the given platform.
+
+        Uses a default (catch-all) SecretContext for now. Per-organisation
+        or per-repository lookup can be added here later once the full
+        webhook context (org, repo) is propagated through the task context.
+        """
+        platform = validator_cls.platform
+        if platform == "github":
+            context = SecretContext(platform="github")
+            return self.secrets_manager.get_github_secrets(context).webhook_secret
+        if platform == "gitlab":
+            context = SecretContext(platform="gitlab")
+            return self.secrets_manager.get_gitlab_secrets(context).webhook_secret
+        raise WebhookValidationError(
+            f"No secret lookup implemented for platform {platform!r}. "
+            f"Add a branch in WebhookValidationHandler._get_webhook_secret()."
+        )

--- a/tests/integration/test_worker_tasks_webhook_validators_handler.py
+++ b/tests/integration/test_worker_tasks_webhook_validators_handler.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Tests for cpu.worker.tasks.webhook_validators.handler: WebhookValidationHandler,
+the TaskHandler registered for TaskType.VALIDATE_WEBHOOK in a WorkerPoolComponent.
+
+Given a task context of {"headers": ..., "body": ...}, the handler detects
+the originating platform from the headers, fetches the matching webhook
+secret from the default (catch-all) secret configuration for that
+platform, and verifies the signature. Any failure (unsupported platform,
+bad signature, missing secret configuration) is raised rather than
+swallowed, so WorkerPoolComponent turns it into an error TASK_COMPLETE
+result.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from cpu.config.secrets import (
+    GitHubAppSecrets,
+    GitLabSecrets,
+    SecretManager,
+    SecretNotFoundError,
+)
+from cpu.config.secrets_context import SecretContext
+from cpu.worker.tasks.types import TaskHandler
+from cpu.worker.tasks.webhook_validators.base import (
+    UnsupportedPlatformError,
+    WebhookValidationError,
+)
+from cpu.worker.tasks.webhook_validators.handler import WebhookValidationHandler
+
+GITHUB_SECRET = "github-webhook-secret"
+GITLAB_SECRET_B64 = base64.standard_b64encode(b"gitlab-signing-key-32-bytes!!!!").decode()
+
+
+def _github_secrets_manager(webhook_secret: str = GITHUB_SECRET) -> MagicMock:
+    manager = MagicMock(spec=SecretManager)
+    manager.get_github_secrets.return_value = GitHubAppSecrets(
+        app_id="123456", private_key=b"pem-bytes", webhook_secret=webhook_secret
+    )
+    return manager
+
+
+def _gitlab_secrets_manager(webhook_secret: str = GITLAB_SECRET_B64) -> MagicMock:
+    manager = MagicMock(spec=SecretManager)
+    manager.get_gitlab_secrets.return_value = GitLabSecrets(token="gitlab-token", webhook_secret=webhook_secret)
+    return manager
+
+
+def _github_request(body: dict[str, Any], secret: str = GITHUB_SECRET) -> dict[str, Any]:
+    raw_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    signature = "sha256=" + hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return {
+        "headers": {"X-GitHub-Event": "pull_request", "X-Hub-Signature-256": signature},
+        "body": body,
+    }
+
+
+def _gitlab_request(body: dict[str, Any], secret_b64: str = GITLAB_SECRET_B64) -> dict[str, Any]:
+    raw_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    webhook_id = "abc-123"
+    timestamp = "1718000000"
+    key = base64.standard_b64decode(secret_b64)
+    mac = hmac.new(key, msg=b".".join([webhook_id.encode(), timestamp.encode(), raw_body]), digestmod=hashlib.sha256)
+    signature = "v1," + base64.standard_b64encode(mac.digest()).decode()
+    return {
+        "headers": {
+            "X-Gitlab-Event": "Push Hook",
+            "Webhook-Signature": signature,
+            "Webhook-Id": webhook_id,
+            "Webhook-Timestamp": timestamp,
+        },
+        "body": body,
+    }
+
+
+class TestWebhookValidationHandlerIsTaskHandler:
+    def test_is_a_task_handler(self) -> None:
+        validator = WebhookValidationHandler(secrets_manager=MagicMock(spec=SecretManager))
+        assert isinstance(validator, TaskHandler)
+
+
+class TestWebhookValidationHandlerGitHub:
+    """Tests for dispatching GitHub webhooks."""
+
+    def test_valid_github_webhook_succeeds(self) -> None:
+        manager = _github_secrets_manager()
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        context = _github_request({"action": "opened", "number": 42})
+
+        result = validator.handle(context)
+
+        assert result == {"platform": "github", "valid": True}
+
+    def test_looks_up_github_secrets_with_platform_context(self) -> None:
+        manager = _github_secrets_manager()
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        validator.handle(_github_request({"action": "opened"}))
+
+        manager.get_github_secrets.assert_called_once()
+        used_context = manager.get_github_secrets.call_args.args[0]
+        assert isinstance(used_context, SecretContext)
+        assert used_context.platform == "github"
+        manager.get_gitlab_secrets.assert_not_called()
+
+    # TODO is this correctly implemented? should we not first validate then handle?
+    def test_invalid_github_signature_raises(self) -> None:
+        manager = _github_secrets_manager(webhook_secret="wrong-secret")
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        context = _github_request({"action": "opened"})
+
+        with pytest.raises(WebhookValidationError):
+            validator.handle(context)
+
+
+class TestWebhookValidationHandlerGitLab:
+    """Tests for dispatching GitLab webhooks."""
+
+    def test_valid_gitlab_webhook_succeeds(self) -> None:
+        manager = _gitlab_secrets_manager()
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        context = _gitlab_request({"object_kind": "push"})
+
+        result = validator.handle(context)
+
+        assert result == {"platform": "gitlab", "valid": True}
+
+    def test_looks_up_gitlab_secrets_with_platform_context(self) -> None:
+        manager = _gitlab_secrets_manager()
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        validator.handle(_gitlab_request({"object_kind": "push"}))
+
+        manager.get_gitlab_secrets.assert_called_once()
+        used_context = manager.get_gitlab_secrets.call_args.args[0]
+        assert isinstance(used_context, SecretContext)
+        assert used_context.platform == "gitlab"
+        manager.get_github_secrets.assert_not_called()
+
+    def test_invalid_gitlab_signature_raises(self) -> None:
+        other_secret = base64.standard_b64encode(b"a-different-key-32-bytes!!!!!!!").decode()
+        manager = _gitlab_secrets_manager(webhook_secret=other_secret)
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        context = _gitlab_request({"object_kind": "push"})
+
+        with pytest.raises(WebhookValidationError):
+            validator.handle(context)
+
+
+class TestWebhookValidationHandlerErrors:
+    """Tests for malformed input and missing secret configuration."""
+
+    def test_unrecognized_platform_raises_unsupported(self) -> None:
+        manager = MagicMock(spec=SecretManager)
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        context = {"headers": {"X-Something-Else": "1"}, "body": {}}
+
+        with pytest.raises(UnsupportedPlatformError):
+            validator.handle(context)
+
+    def test_missing_headers_key_raises(self) -> None:
+        manager = MagicMock(spec=SecretManager)
+        validator = WebhookValidationHandler(secrets_manager=manager)
+
+        with pytest.raises(WebhookValidationError):
+            validator.handle({"body": {}})
+
+    def test_missing_body_key_raises(self) -> None:
+        manager = MagicMock(spec=SecretManager)
+        validator = WebhookValidationHandler(secrets_manager=manager)
+
+        with pytest.raises(WebhookValidationError):
+            validator.handle({"headers": {"X-GitHub-Event": "push"}})
+
+    def test_no_matching_github_secret_config_propagates(self) -> None:
+        manager = MagicMock(spec=SecretManager)
+        manager.get_github_secrets.side_effect = SecretNotFoundError("no github config")
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        context = _github_request({"action": "opened"})
+
+        with pytest.raises(SecretNotFoundError):
+            validator.handle(context)
+
+    def test_no_matching_gitlab_secret_config_propagates(self) -> None:
+        manager = MagicMock(spec=SecretManager)
+        manager.get_gitlab_secrets.side_effect = SecretNotFoundError("no gitlab config")
+        validator = WebhookValidationHandler(secrets_manager=manager)
+        context = _gitlab_request({"object_kind": "push"})
+
+        with pytest.raises(SecretNotFoundError):
+            validator.handle(context)

--- a/tests/integration/test_worker_tasks_webhook_validators_handler.py
+++ b/tests/integration/test_worker_tasks_webhook_validators_handler.py
@@ -18,10 +18,10 @@ result.
 from __future__ import annotations
 
 import base64
-from collections.abc import Mapping
 import hashlib
 import hmac
 import json
+from collections.abc import Mapping
 from typing import Any
 from unittest.mock import MagicMock
 

--- a/tests/integration/test_worker_tasks_webhook_validators_handler.py
+++ b/tests/integration/test_worker_tasks_webhook_validators_handler.py
@@ -18,6 +18,7 @@ result.
 from __future__ import annotations
 
 import base64
+from collections.abc import Mapping
 import hashlib
 import hmac
 import json
@@ -159,6 +160,29 @@ class TestWebhookValidationHandlerGitLab:
 
 class TestWebhookValidationHandlerErrors:
     """Tests for malformed input and missing secret configuration."""
+
+    def test_platform_without_secret_lookup_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from cpu.worker.tasks.webhook_validators.base import PlatformWebhookValidator, get_header
+
+        class _StubValidator(PlatformWebhookValidator):
+            platform = "stub_platform"
+
+            @classmethod
+            def matches(cls, headers: Mapping[str, str]) -> bool:
+                return get_header(headers, "X-Stub-Platform") is not None
+
+            def validate(self, headers: Mapping[str, str], raw_body: bytes, secret: str) -> None:
+                pass  # signature always passes; we're testing the secret lookup branch
+
+        monkeypatch.setattr(
+            "cpu.worker.tasks.webhook_validators.base.WEBHOOK_VALIDATORS",
+            [_StubValidator],
+        )
+        manager = MagicMock(spec=SecretManager)
+        validator = WebhookValidationHandler(secrets_manager=manager)
+
+        with pytest.raises(WebhookValidationError):
+            validator.handle({"headers": {"X-Stub-Platform": "1"}, "body": {}})
 
     def test_unrecognized_platform_raises_unsupported(self) -> None:
         manager = MagicMock(spec=SecretManager)

--- a/tests/unit/test_worker_tasks_webhook_validators_base.py
+++ b/tests/unit/test_worker_tasks_webhook_validators_base.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Tests for cpu.worker.tasks.webhook_validators.base: the
+PlatformWebhookValidator interface, the case-insensitive header lookup
+helper, and the platform-detection registry used to dispatch webhook
+validation to the right platform-specific validator.
+
+The registry is what lets new hosting platforms be supported later by
+adding one new validator module and registering it, without touching
+detect_platform() or anything that calls it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+from cpu.worker.tasks.webhook_validators.base import (
+    WEBHOOK_VALIDATORS,
+    PlatformWebhookValidator,
+    UnsupportedPlatformError,
+    WebhookValidationError,
+    detect_platform,
+    get_header,
+)
+
+
+class TestGetHeader:
+    """Tests for the case-insensitive header lookup helper."""
+
+    # TODO how does it work that we support both exact case AND case insensitive match with the same function
+    def test_exact_case_match(self) -> None:
+        headers = {"X-Hub-Signature-256": "sha256=abc"}
+        assert get_header(headers, "X-Hub-Signature-256") == "sha256=abc"
+
+    def test_case_insensitive_match(self) -> None:
+        headers = {"x-hub-signature-256": "sha256=abc"}
+        assert get_header(headers, "X-Hub-Signature-256") == "sha256=abc"
+
+    def test_mixed_case_match(self) -> None:
+        headers = {"X-hub-SIGNATURE-256": "sha256=abc"}
+        assert get_header(headers, "x-hub-signature-256") == "sha256=abc"
+
+    def test_missing_header_returns_none(self) -> None:
+        headers: Mapping[str, str] = {}
+        assert get_header(headers, "X-Hub-Signature-256") is None
+
+    def test_does_not_partial_match(self) -> None:
+        headers = {"X-Hub-Signature": "sha1=abc"}
+        # "X-Hub-Signature-256" must not match on the "X-Hub-Signature" prefix.
+        assert get_header(headers, "X-Hub-Signature-256") is None
+
+
+class TestPlatformWebhookValidatorInterface:
+    """Tests for the abstract PlatformWebhookValidator base class."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        with pytest.raises(TypeError):
+            PlatformWebhookValidator()  # type: ignore[abstract]
+
+
+class TestWebhookValidationErrors:
+    """Tests for the exception hierarchy."""
+
+    def test_unsupported_platform_error_is_webhook_validation_error(self) -> None:
+        assert issubclass(UnsupportedPlatformError, WebhookValidationError)
+
+    def test_webhook_validation_error_is_exception(self) -> None:
+        assert issubclass(WebhookValidationError, Exception)
+
+
+class _StubValidatorA(PlatformWebhookValidator):
+    """Minimal concrete validator used to test registry/detection in isolation."""
+
+    platform = "stub_a"
+
+    @classmethod
+    def matches(cls, headers: Mapping[str, str]) -> bool:
+        return get_header(headers, "X-Stub-A") is not None
+
+    def validate(self, headers: Mapping[str, str], raw_body: bytes, secret: str) -> None:
+        del headers, raw_body, secret
+
+
+class _StubValidatorB(PlatformWebhookValidator):
+    """Second minimal concrete validator used to test registry/detection."""
+
+    platform = "stub_b"
+
+    @classmethod
+    def matches(cls, headers: Mapping[str, str]) -> bool:
+        return get_header(headers, "X-Stub-B") is not None
+
+    def validate(self, headers: Mapping[str, str], raw_body: bytes, secret: str) -> None:
+        del headers, raw_body, secret
+
+
+class TestWebhookValidatorsRegistry:
+    """Tests for the built-in registry contents."""
+
+    def test_registry_contains_github_validator(self) -> None:
+        from cpu.worker.tasks.webhook_validators.github import GitHubWebhookValidator
+
+        assert GitHubWebhookValidator in WEBHOOK_VALIDATORS
+
+    def test_registry_contains_gitlab_validator(self) -> None:
+        from cpu.worker.tasks.webhook_validators.gitlab import GitLabWebhookValidator
+
+        assert GitLabWebhookValidator in WEBHOOK_VALIDATORS
+
+
+class TestDetectPlatform:
+    """
+    Tests for detect_platform().
+
+    Uses stub validators (via monkeypatching the module-level registry) to
+    isolate dispatch behaviour from real platform logic, plus a couple of
+    tests against the real, built-in registry.
+    """
+
+    def test_detects_matching_validator(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "cpu.worker.tasks.webhook_validators.base.WEBHOOK_VALIDATORS",
+            [_StubValidatorA, _StubValidatorB],
+        )
+        result = detect_platform({"X-Stub-B": "1"})
+        assert result is _StubValidatorB
+
+    def test_first_registered_match_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "cpu.worker.tasks.webhook_validators.base.WEBHOOK_VALIDATORS",
+            [_StubValidatorA, _StubValidatorB],
+        )
+        result = detect_platform({"X-Stub-A": "1", "X-Stub-B": "1"})
+        assert result is _StubValidatorA
+
+    def test_raises_when_no_validator_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "cpu.worker.tasks.webhook_validators.base.WEBHOOK_VALIDATORS",
+            [_StubValidatorA, _StubValidatorB],
+        )
+        with pytest.raises(UnsupportedPlatformError):
+            detect_platform({"X-Something-Else": "1"})
+
+    def test_real_registry_detects_github(self) -> None:
+        from cpu.worker.tasks.webhook_validators.github import GitHubWebhookValidator
+
+        result = detect_platform({"X-GitHub-Event": "push"})
+        assert result is GitHubWebhookValidator
+
+    def test_real_registry_detects_gitlab(self) -> None:
+        from cpu.worker.tasks.webhook_validators.gitlab import GitLabWebhookValidator
+
+        result = detect_platform({"X-Gitlab-Event": "Push Hook"})
+        assert result is GitLabWebhookValidator
+
+    def test_real_registry_raises_for_unknown_platform(self) -> None:
+        with pytest.raises(UnsupportedPlatformError):
+            detect_platform({"X-Bitbucket-Event": "repo:push"})

--- a/tests/unit/test_worker_tasks_webhook_validators_base.py
+++ b/tests/unit/test_worker_tasks_webhook_validators_base.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 import pytest
+
 from cpu.worker.tasks.webhook_validators.base import (
     WEBHOOK_VALIDATORS,
     PlatformWebhookValidator,

--- a/tests/unit/test_worker_tasks_webhook_validators_github.py
+++ b/tests/unit/test_worker_tasks_webhook_validators_github.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Tests for cpu.worker.tasks.webhook_validators.github: GitHubWebhookValidator.
+
+Verifies webhook signatures per
+https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+
+Both the recommended SHA-256 signature (X-Hub-Signature-256) and the
+legacy SHA-1 signature (X-Hub-Signature) are supported; SHA-256 is
+preferred when both headers are present.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+import pytest
+from cpu.worker.tasks.webhook_validators.base import WebhookValidationError
+from cpu.worker.tasks.webhook_validators.github import GitHubWebhookValidator
+
+SECRET = "super-secret-token"
+RAW_BODY = b'{"action":"opened","number":42}'
+
+
+def _sha256_signature(secret: str, raw_body: bytes) -> str:
+    mac = hmac.new(secret.encode(), raw_body, hashlib.sha256)
+    return f"sha256={mac.hexdigest()}"
+
+
+def _sha1_signature(secret: str, raw_body: bytes) -> str:
+    mac = hmac.new(secret.encode(), raw_body, hashlib.sha1)
+    return f"sha1={mac.hexdigest()}"
+
+
+class TestGitHubWebhookValidatorMatches:
+    """Tests for platform self-identification from request headers."""
+
+    def test_matches_on_event_header(self) -> None:
+        assert GitHubWebhookValidator.matches({"X-GitHub-Event": "push"}) is True
+
+    def test_matches_on_sha256_signature_header(self) -> None:
+        assert GitHubWebhookValidator.matches({"X-Hub-Signature-256": "sha256=abc"}) is True
+
+    def test_matches_on_sha1_signature_header(self) -> None:
+        assert GitHubWebhookValidator.matches({"X-Hub-Signature": "sha1=abc"}) is True
+
+    def test_does_not_match_unrelated_headers(self) -> None:
+        assert GitHubWebhookValidator.matches({"X-Gitlab-Event": "Push Hook"}) is False
+
+    def test_platform_attribute(self) -> None:
+        assert GitHubWebhookValidator.platform == "github"
+
+
+class TestGitHubWebhookValidatorValidateSha256:
+    """Tests for the preferred SHA-256 signature scheme."""
+
+    def test_valid_sha256_signature_passes(self) -> None:
+        headers = {"X-Hub-Signature-256": _sha256_signature(SECRET, RAW_BODY)}
+        GitHubWebhookValidator().validate(headers, RAW_BODY, SECRET)  # must not raise
+
+    def test_invalid_sha256_signature_raises(self) -> None:
+        headers = {"X-Hub-Signature-256": "sha256=" + "0" * 64}
+        with pytest.raises(WebhookValidationError):
+            GitHubWebhookValidator().validate(headers, RAW_BODY, SECRET)
+
+    def test_sha256_preferred_over_sha1_when_both_present(self) -> None:
+        headers = {
+            "X-Hub-Signature-256": _sha256_signature(SECRET, RAW_BODY),
+            "X-Hub-Signature": "sha1=" + "0" * 40,  # would fail verification if checked
+        }
+        GitHubWebhookValidator().validate(headers, RAW_BODY, SECRET)  # must not raise
+
+    def test_malformed_sha256_header_raises(self) -> None:
+        headers = {"X-Hub-Signature-256": "not-a-valid-signature"}
+        with pytest.raises(WebhookValidationError):
+            GitHubWebhookValidator().validate(headers, RAW_BODY, SECRET)
+
+
+class TestGitHubWebhookValidatorValidateSha1:
+    """Tests for the legacy SHA-1 signature scheme (fallback only)."""
+
+    def test_valid_sha1_signature_passes_when_sha256_absent(self) -> None:
+        headers = {"X-Hub-Signature": _sha1_signature(SECRET, RAW_BODY)}
+        GitHubWebhookValidator().validate(headers, RAW_BODY, SECRET)  # must not raise
+
+    def test_invalid_sha1_signature_raises(self) -> None:
+        headers = {"X-Hub-Signature": "sha1=" + "0" * 40}
+        with pytest.raises(WebhookValidationError):
+            GitHubWebhookValidator().validate(headers, RAW_BODY, SECRET)
+
+
+class TestGitHubWebhookValidatorValidateMissingOrBadInput:
+    """Tests for missing headers and edge cases."""
+
+    def test_missing_signature_headers_raises(self) -> None:
+        with pytest.raises(WebhookValidationError):
+            GitHubWebhookValidator().validate({"X-GitHub-Event": "push"}, RAW_BODY, SECRET)
+
+    def test_empty_headers_raises(self) -> None:
+        with pytest.raises(WebhookValidationError):
+            GitHubWebhookValidator().validate({}, RAW_BODY, SECRET)
+
+    def test_wrong_secret_fails_verification(self) -> None:
+        headers = {"X-Hub-Signature-256": _sha256_signature("the-right-secret", RAW_BODY)}
+        with pytest.raises(WebhookValidationError):
+            GitHubWebhookValidator().validate(headers, RAW_BODY, "the-wrong-secret")
+
+    def test_case_insensitive_header_lookup(self) -> None:
+        headers = {"x-hub-signature-256": _sha256_signature(SECRET, RAW_BODY)}
+        GitHubWebhookValidator().validate(headers, RAW_BODY, SECRET)  # must not raise

--- a/tests/unit/test_worker_tasks_webhook_validators_github.py
+++ b/tests/unit/test_worker_tasks_webhook_validators_github.py
@@ -19,6 +19,7 @@ import hashlib
 import hmac
 
 import pytest
+
 from cpu.worker.tasks.webhook_validators.base import WebhookValidationError
 from cpu.worker.tasks.webhook_validators.github import GitHubWebhookValidator
 

--- a/tests/unit/test_worker_tasks_webhook_validators_gitlab.py
+++ b/tests/unit/test_worker_tasks_webhook_validators_gitlab.py
@@ -22,6 +22,7 @@ import hashlib
 import hmac
 
 import pytest
+
 from cpu.worker.tasks.webhook_validators.base import WebhookValidationError
 from cpu.worker.tasks.webhook_validators.gitlab import GitLabWebhookValidator
 

--- a/tests/unit/test_worker_tasks_webhook_validators_gitlab.py
+++ b/tests/unit/test_worker_tasks_webhook_validators_gitlab.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 CPU contributors
+"""
+CPU - The next-generation EESSI build-and-deploy bot.
+
+Tests for cpu.worker.tasks.webhook_validators.gitlab: GitLabWebhookValidator.
+
+Verifies webhook signatures using GitLab's signing-token scheme
+(Webhook-Signature header, HMAC-SHA256, "v1,<base64>"), introduced in
+GitLab 19.0 (generally available in 19.1). The legacy plain secret-token
+scheme (X-Gitlab-Token header, used by GitLab < 19) is intentionally
+NOT supported: a request carrying only that header is recognised as a
+GitLab request but rejected with a clear error.
+
+See https://docs.gitlab.com/user/project/integrations/webhooks/
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+
+import pytest
+from cpu.worker.tasks.webhook_validators.base import WebhookValidationError
+from cpu.worker.tasks.webhook_validators.gitlab import GitLabWebhookValidator
+
+# base64-encoded signing token (decodes to a 32-byte raw key)
+SECRET_B64 = base64.standard_b64encode(b"gitlab-signing-key-32-bytes!!!!").decode()
+RAW_BODY = b'{"object_kind":"push","event_type":"push"}'
+WEBHOOK_ID = "3c5c0404-c866-44bc-a5f6-452bb1bfc76e"
+TIMESTAMP = "1718000000"
+
+
+def _v1_signature(secret_b64: str, webhook_id: str, timestamp: str, raw_body: bytes) -> str:
+    key = base64.standard_b64decode(secret_b64)
+    components = (webhook_id.encode(), timestamp.encode(), raw_body)
+    mac = hmac.new(key, msg=b".".join(components), digestmod=hashlib.sha256)
+    return "v1," + base64.standard_b64encode(mac.digest()).decode()
+
+
+def _headers(
+    signature: str | None = "unset",
+    webhook_id: str | None = WEBHOOK_ID,
+    timestamp: str | None = TIMESTAMP,
+) -> dict[str, str]:
+    """Build GitLab request headers; pass signature=None to omit it entirely."""
+    headers: dict[str, str] = {"X-Gitlab-Event": "Push Hook"}
+    if signature == "unset":
+        signature = _v1_signature(SECRET_B64, WEBHOOK_ID, TIMESTAMP, RAW_BODY)
+    if signature is not None:
+        headers["Webhook-Signature"] = signature
+    if webhook_id is not None:
+        headers["Webhook-Id"] = webhook_id
+    if timestamp is not None:
+        headers["Webhook-Timestamp"] = timestamp
+    return headers
+
+
+class TestGitLabWebhookValidatorMatches:
+    """Tests for platform self-identification from request headers."""
+
+    def test_matches_on_event_header(self) -> None:
+        assert GitLabWebhookValidator.matches({"X-Gitlab-Event": "Push Hook"}) is True
+
+    def test_matches_on_webhook_signature_header(self) -> None:
+        assert GitLabWebhookValidator.matches({"Webhook-Signature": "v1,abc"}) is True
+
+    def test_matches_on_legacy_token_header(self) -> None:
+        # Still recognised as GitLab, so validate() can reject it with a
+        # clear "unsupported scheme" error instead of "unknown platform".
+        assert GitLabWebhookValidator.matches({"X-Gitlab-Token": "secret"}) is True
+
+    def test_does_not_match_unrelated_headers(self) -> None:
+        assert GitLabWebhookValidator.matches({"X-GitHub-Event": "push"}) is False
+
+    def test_platform_attribute(self) -> None:
+        assert GitLabWebhookValidator.platform == "gitlab"
+
+
+class TestGitLabWebhookValidatorValidateSuccess:
+    """Tests for successful signature verification."""
+
+    def test_valid_signature_passes(self) -> None:
+        GitLabWebhookValidator().validate(_headers(), RAW_BODY, SECRET_B64)  # must not raise
+
+    def test_one_of_multiple_space_separated_signatures_matches(self) -> None:
+        valid = _v1_signature(SECRET_B64, WEBHOOK_ID, TIMESTAMP, RAW_BODY)
+        signature_header = f"v1,bogus== {valid}"
+        GitLabWebhookValidator().validate(_headers(signature_header), RAW_BODY, SECRET_B64)
+
+    def test_case_insensitive_header_lookup(self) -> None:
+        signature = _v1_signature(SECRET_B64, WEBHOOK_ID, TIMESTAMP, RAW_BODY)
+        headers = {
+            "x-gitlab-event": "Push Hook",
+            "webhook-signature": signature,
+            "webhook-id": WEBHOOK_ID,
+            "webhook-timestamp": TIMESTAMP,
+        }
+        GitLabWebhookValidator().validate(headers, RAW_BODY, SECRET_B64)
+
+
+class TestGitLabWebhookValidatorValidateFailure:
+    """Tests for rejected requests."""
+
+    def test_invalid_signature_raises(self) -> None:
+        bogus = "v1," + base64.standard_b64encode(b"0" * 32).decode()
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate(_headers(bogus), RAW_BODY, SECRET_B64)
+
+    def test_wrong_secret_fails_verification(self) -> None:
+        valid_for_other_secret = _v1_signature(
+            base64.standard_b64encode(b"a-different-key-32-bytes!!!!!!!").decode(),
+            WEBHOOK_ID,
+            TIMESTAMP,
+            RAW_BODY,
+        )
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate(_headers(valid_for_other_secret), RAW_BODY, SECRET_B64)
+
+    def test_missing_webhook_signature_header_raises(self) -> None:
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate(_headers(signature=None), RAW_BODY, SECRET_B64)
+
+    # TODO how about a test with a header that has both the legacy token and the new signing token?
+    def test_legacy_token_only_request_is_explicitly_rejected(self) -> None:
+        headers = {"X-Gitlab-Event": "Push Hook", "X-Gitlab-Token": "plain-secret"}
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate(headers, RAW_BODY, SECRET_B64)
+
+    def test_signature_without_v1_prefix_raises(self) -> None:
+        headers = _headers(signature="v2,deadbeef")
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate(headers, RAW_BODY, SECRET_B64)
+
+    def test_missing_webhook_id_raises(self) -> None:
+        signature = _v1_signature(SECRET_B64, WEBHOOK_ID, TIMESTAMP, RAW_BODY)
+        headers = _headers(signature=signature, webhook_id=None)
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate(headers, RAW_BODY, SECRET_B64)
+
+    def test_missing_timestamp_raises(self) -> None:
+        signature = _v1_signature(SECRET_B64, WEBHOOK_ID, TIMESTAMP, RAW_BODY)
+        headers = _headers(signature=signature, timestamp=None)
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate(headers, RAW_BODY, SECRET_B64)
+
+    def test_non_base64_secret_raises(self) -> None:
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate(_headers(), RAW_BODY, "abc")
+
+    def test_empty_headers_raises(self) -> None:
+        with pytest.raises(WebhookValidationError):
+            GitLabWebhookValidator().validate({}, RAW_BODY, SECRET_B64)


### PR DESCRIPTION
Adds webhook signature validation as a TaskHandler for
`TaskType.VALIDATE_WEBHOOK`, supporting GitHub and GitLab (19+ only).

## New package: `cpu.worker.tasks.webhook_validators`

- `base.py`: `PlatformWebhookValidator ABC`, `WebhookValidationError` /
  `UnsupportedPlatformError` exception hierarchy, case-insensitive
  `get_header()` helper, `WEBHOOK_VALIDATORS` registry, and
  `detect_platform()` dispatcher.

- `github.py`: `GitHubWebhookValidator` verifies `HMAC-SHA256`
  (`X-Hub-Signature-256`, preferred) with SHA-1 (`X-Hub-Signature`) as
  fallback.

- `gitlab.py`: `GitLabWebhookValidator` verifies the GitLab 19+
  signing-token scheme (`Webhook-Signature`: `v1,<base64-hmac-sha256>`).
  The legacy `X-Gitlab-Token` plain-secret scheme is explicitly rejected
  with a clear error message.

- `handler.py`: `WebhookValidationHandler(TaskHandler)`, registered for
  `TaskType.VALIDATE_WEBHOOK`. Detects the platform from request headers,
  fetches the webhook secret via `SecretManager` (default/catch-all
  context), and delegates signature verification to the matching
  validator.

## Extensibility

Adding support for a new hosting platform requires only a new validator
module that self-registers in `WEBHOOK_VALIDATORS` at import time, plus a
corresponding import in `__init__.py`. No changes to `detect_platform()` or
any caller are needed.

## Notes

- GitLab support is limited to version 19+ (signing-token scheme). The
  legacy token scheme predating it is out of scope.
- Webhooks arriving via Smee may fail signature verification due to
  Smee re-serialising the JSON payload before forwarding. This is a
  known Smee limitation (development use only) and is documented in
  `handler.py`.

## Tests

- Unit tests for the base registry/detection logic, GitHub validator,
  and GitLab validator.
- Integration test for `WebhookValidationHandler` covering both platforms,
  secret lookup, and error paths.